### PR TITLE
add disable cache in LazyTensorFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ htmlcov/
 .coverage_*
 .pytest_cache/
 .vscode
+.idea
 *.log
 *.pyc
 examples/paddle_case/log

--- a/fastsafetensors/loader.py
+++ b/fastsafetensors/loader.py
@@ -46,6 +46,7 @@ class SafeTensorsFileLoader:
         max_threads: int = 16,
         nogds: bool = False,
         set_numa: bool = True,
+        disable_cache: bool = True,
         debug_log: bool = False,
         framework="pytorch",
     ):
@@ -55,6 +56,7 @@ class SafeTensorsFileLoader:
         self.debug_log = debug_log
         self.meta: Dict[str, Tuple[SafeTensorsMetadata, int]] = {}
         self.frames = OrderedDict[str, TensorFrame]()
+        self.disable_cache = disable_cache
         global loaded_nvidia
         if not loaded_nvidia:
             fstcpp.load_nvidia_functions()
@@ -154,6 +156,7 @@ class SafeTensorsFileLoader:
                 self.reader,
                 self.framework,
                 self.debug_log,
+                disable_cache=self.disable_cache,
             )
             factory.submit_io(use_buf_register, max_copy_block_size)
             factories[rank].append(factory)


### PR DESCRIPTION
The first in #29

Disables the batch tensor cache by default since it is unnecessary for most scenarios and consumes extra GPU memory.


## Example Configuration:

- Backend/Framework: SGLang with TP8

- Model: deepseek-r1 (each file: 4GiB)

### Extra Memory Comparison:

- With disable_cache=True: ~5.7 GiB = 4 GiB (file) + 1.7 GiB (largest tensor)

- With disable_cache=False: 32 GiB = 4 GiB * 8 (files)

Conclusion: Disabling the cache reduces peak GPU memory usage by approximately 82%.