### PR TITLE
[Bugfix] fix hipMemcpyKind enum

### DIFF
--- a/fastsafetensors/cpp/ext.hpp
+++ b/fastsafetensors/cpp/ext.hpp
@@ -39,7 +39,12 @@ typedef struct CUfileError { CUfileOpError err; } CUfileError_t;
 // Define minimal CUDA/HIP types for both platforms to avoid compile-time dependencies
 // We load all GPU functions dynamically at runtime via dlopen()
 typedef enum cudaError { cudaSuccess = 0, cudaErrorMemoryAllocation = 2 } cudaError_t;
+// Platform-specific enum values - CUDA and HIP have different values for HostToDevice
+#ifdef USE_ROCM
+enum cudaMemcpyKind { cudaMemcpyHostToDevice=1, cudaMemcpyDefault = 4 };
+#else
 enum cudaMemcpyKind { cudaMemcpyHostToDevice=2, cudaMemcpyDefault = 4 };
+#endif
 
 
 typedef enum CUfileFeatureFlags {


### PR DESCRIPTION
Align the enum to be the same as the one found in

```bash
$ grep hipMemcpyHostToDevice /opt/rocm/include/hip/driver_types.h 
    hipMemcpyHostToDevice = 1,          ///< Host-to-Device Copy
```

I have validated that the unit tests are passing and it works with vLLM. Validated the accuracy of DeepSeek-R1 loaded with fastsafetensors.