### PR TITLE
add copier registry

### DIFF
--- a/fastsafetensors/copier/__init__.py
+++ b/fastsafetensors/copier/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from .base import CopierInterface
+from .gds import GdsFileCopier
+from .nogds import NoGdsFileCopier
+from .registry import (
+    CopierConstructFunc,
+    CopierType,
+    create_copier_constructor,
+    register_copier_constructor,
+)

--- a/fastsafetensors/copier/gds.py
+++ b/fastsafetensors/copier/gds.py
@@ -8,7 +8,8 @@ from ..common import SafeTensorsMetadata, init_logger, is_gpu_found
 from ..frameworks import FrameworkOpBase, TensorBase
 from ..st_types import Device, DeviceType, DType
 from .base import CopierInterface
-from .nogds import NoGdsFileCopier
+from .nogds import load_library_func, new_nogds_file_copier
+from .registry import CopierConstructFunc, register_copier_constructor
 
 logger = init_logger(__name__)
 
@@ -158,17 +159,31 @@ class GdsFileCopier(CopierInterface):
         )
 
 
+_inited_gds = False
+
+
+def init_gds():
+    load_library_func()
+    global _inited_gds
+    if not _inited_gds:
+        if fstcpp.init_gds() != 0:
+            raise Exception(f"[FAIL] init_gds()")
+        _inited_gds = True
+
+
+@register_copier_constructor("gds")
 def new_gds_file_copier(
     device: Device,
     bbuf_size_kb: int = 16 * 1024,
     max_threads: int = 16,
-    nogds: bool = False,
-):
+) -> CopierConstructFunc:
+    init_gds()
     device_is_not_cpu = device.type != DeviceType.CPU
     if device_is_not_cpu and not is_gpu_found():
         raise Exception(
             "[FAIL] GPU runtime library (libcudart.so or libamdhip64.so) does not exist"
         )
+    nogds = False
     if device_is_not_cpu and not nogds:
         gds_supported = fstcpp.is_gds_supported(
             device.index if device.index is not None else 0
@@ -190,18 +205,7 @@ def new_gds_file_copier(
 
     device_id = device.index if device.index is not None else 0
     if nogds:
-        nogds_reader = fstcpp.nogds_file_reader(
-            False, bbuf_size_kb, max_threads, device_is_not_cpu, device_id
-        )
-
-        def construct_nogds_copier(
-            metadata: SafeTensorsMetadata,
-            device: Device,
-            framework: FrameworkOpBase,
-        ) -> CopierInterface:
-            return NoGdsFileCopier(metadata, device, nogds_reader, framework)
-
-        return construct_nogds_copier
+        return new_nogds_file_copier(device, bbuf_size_kb, max_threads)
 
     reader = fstcpp.gds_file_reader(max_threads, device_is_not_cpu, device_id)
 

--- a/fastsafetensors/copier/nogds.py
+++ b/fastsafetensors/copier/nogds.py
@@ -6,8 +6,9 @@ from typing import Dict, List
 from .. import cpp as fstcpp
 from ..common import SafeTensorsMetadata
 from ..frameworks import FrameworkOpBase, TensorBase
-from ..st_types import Device, DType
+from ..st_types import Device, DeviceType, DType
 from .base import CopierInterface
+from .registry import CopierConstructFunc, register_copier_constructor
 
 
 class NoGdsFileCopier(CopierInterface):
@@ -64,3 +65,39 @@ class NoGdsFileCopier(CopierInterface):
         return self.metadata.get_tensors(
             gbuf, self.device, self.metadata.header_length, dtype=dtype
         )
+
+
+_loaded_library = False
+
+
+def load_library_func():
+    global _loaded_library
+    if not _loaded_library:
+        fstcpp.load_library_functions()
+        _loaded_library = True
+
+
+@register_copier_constructor("nogds")
+def new_nogds_file_copier(
+    device: Device,
+    bbuf_size_kb: int = 16 * 1024,
+    max_threads: int = 16,
+) -> CopierConstructFunc:
+    load_library_func()
+    device_is_not_cpu = device.type != DeviceType.CPU
+    if device_is_not_cpu and not fstcpp.is_cuda_found():
+        raise Exception("[FAIL] libcudart.so does not exist")
+
+    device_id = device.index if device.index is not None else 0
+    nogds_reader = fstcpp.nogds_file_reader(
+        False, bbuf_size_kb, max_threads, device_is_not_cpu, device_id
+    )
+
+    def construct_nogds_copier(
+        metadata: SafeTensorsMetadata,
+        device: Device,
+        framework: FrameworkOpBase,
+    ) -> CopierInterface:
+        return NoGdsFileCopier(metadata, device, nogds_reader, framework)
+
+    return construct_nogds_copier

--- a/fastsafetensors/copier/registry.py
+++ b/fastsafetensors/copier/registry.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable, Dict
+
+from ..common import SafeTensorsMetadata
+from ..frameworks import FrameworkOpBase
+from ..st_types import Device
+from .base import CopierInterface
+
+CopierType = str
+CopierConstructFunc = Callable[
+    [SafeTensorsMetadata, Device, FrameworkOpBase], CopierInterface
+]
+CopierConstructorFactory = Callable[..., CopierConstructFunc]
+
+_copier_registry: Dict[CopierType, CopierConstructorFactory] = {}
+
+
+def register_copier_constructor(copier_type: CopierType):
+    def decorator(factory_func: CopierConstructorFactory) -> CopierConstructorFactory:
+        _copier_registry[copier_type] = factory_func
+        return factory_func
+
+    return decorator
+
+
+def create_copier_constructor(
+    copier_type: CopierType, device: Device, **kwargs
+) -> CopierConstructFunc:
+    if copier_type not in _copier_registry:
+        raise KeyError(
+            f"Copier type '{copier_type}' is not registered. "
+            f"Available types: {list(_copier_registry.keys())}"
+        )
+
+    factory_func = _copier_registry[copier_type]
+    return factory_func(device, **kwargs)

--- a/fastsafetensors/loader.py
+++ b/fastsafetensors/loader.py
@@ -11,7 +11,7 @@ from .common import (
     init_logger,
     set_debug,
 )
-from .copier.gds import new_gds_file_copier
+from .copier import CopierConstructFunc, CopierType, create_copier_constructor
 from .file_buffer import FilesBufferOnDevice
 from .frameworks import TensorBase, get_framework_op
 from .st_types import Device, DType
@@ -42,7 +42,7 @@ class BaseSafeTensorsFileLoader:
         self,
         pg: Optional[Any],
         device: Device,
-        copier_constructor,
+        copier_type: CopierType,
         set_numa: bool = True,
         disable_cache: bool = True,
         framework="pytorch",
@@ -55,7 +55,11 @@ class BaseSafeTensorsFileLoader:
         self.frames = OrderedDict[str, TensorFrame]()
         self.disable_cache = disable_cache
         self.init_numa(set_numa)
-        self.copier_constructor = copier_constructor
+        self.copier_constructor: CopierConstructFunc = create_copier_constructor(
+            copier_type=copier_type,
+            device=device,
+            **kwargs,
+        )
 
     def init_numa(self, set_numa: bool = True):
         global gl_set_numa
@@ -186,25 +190,19 @@ class SafeTensorsFileLoader(BaseSafeTensorsFileLoader):
         self.device = self.framework.get_device(device, self.pg)
 
         fstcpp.set_debug_log(debug_log)
-        if debug_log:
-            set_debug()
-        global loaded_library
-        if not loaded_library:
-            fstcpp.load_library_functions()
-            if not nogds:
-                # no need to init gds and consume 10s+ in none-gds case
-                if fstcpp.init_gds() != 0:
-                    raise Exception(f"[FAIL] init_gds()")
-            loaded_library = True
-
-        copier = new_gds_file_copier(self.device, bbuf_size_kb, max_threads, nogds)
+        if nogds:
+            copier_type = "nogds"
+        else:
+            copier_type = "gds"
         super().__init__(
             pg,
             self.device,
-            copier,
+            copier_type,
             set_numa,
             disable_cache,
             framework,
+            bbuf_size_kb=bbuf_size_kb,
+            max_threads=max_threads,
             **kwargs,
         )
 


### PR DESCRIPTION
This PR implements a copier registry system that enables extensible support for multiple filesystem types. When adding support for additional filesystems such as HDFS, OSS, or other network filesystems, developers can simply register new copier constructors using the register_copier_constructor decorator. The top-level loader interface can then select the appropriate copier implementation through a simple string-based copier_type parameter, providing a clean and pluggable architecture for filesystem abstraction.