### PR TITLE
fix: avoid unnecessary copier construction for non-owned files

### DIFF
--- a/fastsafetensors/loader.py
+++ b/fastsafetensors/loader.py
@@ -128,8 +128,11 @@ class BaseSafeTensorsFileLoader:
         factory_idx_bits = math.ceil(math.log2(len(self.meta) + 1))
         lidx = 1
         for _, (meta, rank) in sorted(self.meta.items(), key=lambda x: x[0]):
-            copier = self.copier_constructor(meta, self.device, self.framework)
             self_rank = self.pg.rank() == rank
+            if self_rank:
+                copier = self.copier_constructor(meta, self.device, self.framework)
+            else:
+                copier = None
             factory = LazyTensorFactory(
                 meta,
                 self.device,

--- a/fastsafetensors/tensor_factory.py
+++ b/fastsafetensors/tensor_factory.py
@@ -20,7 +20,7 @@ class LazyTensorFactory:
         local_rank: bool,
         factory_idx_bits: int,
         lidx: int,
-        copier: CopierInterface,
+        copier: Optional[CopierInterface],
         framework: FrameworkOpBase,
         disable_cache=True,
     ):


### PR DESCRIPTION
## Problem
Copiers were created for all files regardless of rank ownership, causing unnecessary file open operations in nogds mode.

## Fix
Only create copier for files owned by the current rank; set to None otherwise.