### PR TITLE
feat: add 3FS copier support

### DIFF
--- a/.github/workflows/test-torch.yaml
+++ b/.github/workflows/test-torch.yaml
@@ -58,6 +58,7 @@ jobs:
           mkdir -p /tmp/pytest-log
           export TEST_FASTSAFETENSORS_FRAMEWORK=pytorch
           COVERAGE_FILE=.coverage_0 pytest -s --cov=${LIBDIR} test_fastsafetensors.py > /tmp/pytest-log/0.log 2>&1
+          COVERAGE_FILE=.coverage_3fs pytest -s --cov=${LIBDIR} threefs/ > /tmp/pytest-log/threefs.log 2>&1
           COVERAGE_FILE=.coverage_1 torchrun --nnodes=1 --master_addr=0.0.0.0 --master_port=1234 --node_rank=0 test_multi.py --cov=${LIBDIR} -s test_multi.py > /tmp/pytest-log/1.log 2>&1
           COVERAGE_FILE=.coverage_2 torchrun --nnodes=4 --master_addr=0.0.0.0 --master_port=1234 --node_rank=0 test_multi.py --cov=${LIBDIR} -s test_multi.py > /tmp/pytest-log/2.log 2>&1 &
           COVERAGE_FILE=.coverage_3 torchrun --nnodes=4 --master_addr=0.0.0.0 --master_port=1234 --node_rank=1 test_multi.py --cov=${LIBDIR} -s test_multi.py > /tmp/pytest-log/3.log 2>&1 &

--- a/fastsafetensors/copier/__init__.py
+++ b/fastsafetensors/copier/__init__.py
@@ -9,6 +9,5 @@ from .registry import (
     create_copier_constructor,
     register_copier_constructor,
 )
-from .unified import UnifiedMemCopier
-
 from .threefs import ThreeFSFileCopier
+from .unified import UnifiedMemCopier

--- a/fastsafetensors/copier/__init__.py
+++ b/fastsafetensors/copier/__init__.py
@@ -10,3 +10,5 @@ from .registry import (
     register_copier_constructor,
 )
 from .unified import UnifiedMemCopier
+
+from .threefs import ThreeFSFileCopier

--- a/fastsafetensors/copier/gds.py
+++ b/fastsafetensors/copier/gds.py
@@ -176,6 +176,7 @@ def new_gds_file_copier(
     device: Device,
     bbuf_size_kb: int = 16 * 1024,
     max_threads: int = 16,
+    **kwargs,
 ) -> CopierConstructFunc:
     init_gds()
     device_is_not_cpu = device.type != DeviceType.CPU

--- a/fastsafetensors/copier/nogds.py
+++ b/fastsafetensors/copier/nogds.py
@@ -82,6 +82,7 @@ def new_nogds_file_copier(
     device: Device,
     bbuf_size_kb: int = 16 * 1024,
     max_threads: int = 16,
+    **kwargs,
 ) -> CopierConstructFunc:
     load_library_func()
     device_is_not_cpu = device.type != DeviceType.CPU

--- a/fastsafetensors/copier/threefs.py
+++ b/fastsafetensors/copier/threefs.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict
+
+from fastsafetensor_3fs_reader import ThreeFSFileReader
+from fastsafetensors import cpp as fstcpp
+from fastsafetensors.common import SafeTensorsMetadata, init_logger
+from fastsafetensors.copier.base import CopierInterface
+from fastsafetensors.copier.registry import (
+    CopierConstructFunc,
+    register_copier_constructor,
+)
+from fastsafetensors.frameworks import FrameworkOpBase, TensorBase
+from fastsafetensors.st_types import Device, DType
+
+logger = init_logger(__name__)
+
+class ThreeFSFileCopier(CopierInterface):
+    def __init__(
+        self,
+        metadata: SafeTensorsMetadata,
+        device: Device,
+        reader: ThreeFSFileReader,
+        framework: FrameworkOpBase,
+    ):
+        self.framework = framework
+        self.metadata = metadata
+        self.device = device
+        self.reader = reader
+
+    def submit_io(
+        self, use_buf_register: bool, max_copy_block_size: int
+    ) -> fstcpp.gds_device_buffer:
+        offset = self.metadata.header_length
+        length = self.metadata.size_bytes - self.metadata.header_length
+
+        gbuf = self.framework.alloc_tensor_memory(length, self.device)
+
+        logger.info(
+            f"Reading {length} bytes from {self.metadata.src} using chunked read"
+        )
+
+        total_read = self.reader.read_chunked(
+            path=self.metadata.src,
+            dev_ptr=gbuf.get_base_address(),
+            file_offset=offset,
+            total_length=length,
+            chunk_size=max_copy_block_size if max_copy_block_size > 0 else 0,
+        )
+
+        if total_read != length:
+            raise Exception(
+                f"ThreeFSFileCopier.submit_io: incomplete read, "
+                f"expected={length}, actual={total_read}"
+            )
+
+        logger.info(f"Successfully read {total_read} bytes")
+
+        return gbuf
+
+    def wait_io(
+        self,
+        gbuf: fstcpp.gds_device_buffer,
+        dtype: DType = DType.AUTO,
+        noalign: bool = False,
+    ) -> Dict[str, TensorBase]:
+        # read_chunked is synchronous; data is fully read in submit_io
+        return self.metadata.get_tensors(
+            gbuf, self.device, self.metadata.header_length, dtype=dtype
+        )
+
+@register_copier_constructor("3fs")
+def new_threefs_file_copier(
+    device: Device,
+    mount_point: str,
+    entries: int = 64,
+    io_depth: int = 0,
+    buffer_size: int = 64 * 1024 * 1024,
+    **kwargs,
+) -> CopierConstructFunc:
+    reader = ThreeFSFileReader(
+        mount_point=mount_point,
+        entries=entries,
+        io_depth=io_depth,
+        buffer_size=buffer_size,
+    )
+
+    def construct_copier(
+        metadata: SafeTensorsMetadata,
+        device: Device,
+        framework: FrameworkOpBase,
+    ) -> CopierInterface:
+        return ThreeFSFileCopier(metadata, device, reader, framework)
+
+    construct_copier.reader = reader  # type: ignore[attr-defined]
+
+    return construct_copier

--- a/fastsafetensors/copier/threefs.py
+++ b/fastsafetensors/copier/threefs.py
@@ -2,7 +2,6 @@
 
 from typing import Dict
 
-from fastsafetensor_3fs_reader import ThreeFSFileReader
 from fastsafetensors import cpp as fstcpp
 from fastsafetensors.common import SafeTensorsMetadata, init_logger
 from fastsafetensors.copier.base import CopierInterface
@@ -15,12 +14,13 @@ from fastsafetensors.st_types import Device, DType
 
 logger = init_logger(__name__)
 
+
 class ThreeFSFileCopier(CopierInterface):
     def __init__(
         self,
         metadata: SafeTensorsMetadata,
         device: Device,
-        reader: ThreeFSFileReader,
+        reader,  # duck-typed: must have read_chunked(path, dev_ptr, file_offset, total_length, chunk_size) -> int
         framework: FrameworkOpBase,
     ):
         self.framework = framework
@@ -69,6 +69,7 @@ class ThreeFSFileCopier(CopierInterface):
             gbuf, self.device, self.metadata.header_length, dtype=dtype
         )
 
+
 @register_copier_constructor("3fs")
 def new_threefs_file_copier(
     device: Device,
@@ -78,6 +79,8 @@ def new_threefs_file_copier(
     buffer_size: int = 64 * 1024 * 1024,
     **kwargs,
 ) -> CopierConstructFunc:
+    from fastsafetensor_3fs_reader import ThreeFSFileReader
+
     reader = ThreeFSFileReader(
         mount_point=mount_point,
         entries=entries,

--- a/fastsafetensors/parallel_loader.py
+++ b/fastsafetensors/parallel_loader.py
@@ -153,6 +153,9 @@ class PipelineParallel:
         # Logging setup - get from environment variable, default to False
         self.print_log = os.getenv("FASTSAFETENSORS_DEBUG", "false").lower() == "true"
         self.log_prefix = f"PG{pg.rank() if pg is not None else 0}"
+        # When pg.size() == 1, tensors reference the underlying gbuf memory
+        # which will be freed in fb.close(). Clone to ensure data survives.
+        self.need_clone = pg.size() == 1 if pg is not None else True
 
         fstcpp.set_gil_release(True)
 
@@ -311,6 +314,8 @@ class PipelineParallel:
             ) as timer:
                 for key in batch.keys:
                     tensor = batch.fb.get_tensor(key)
+                    if self.need_clone:
+                        tensor = tensor.clone()
                     yield key, tensor
             get_tensor_time = timer.elapsed_ms
         finally:

--- a/fastsafetensors/parallel_loader.py
+++ b/fastsafetensors/parallel_loader.py
@@ -153,6 +153,7 @@ class PipelineParallel:
         # Logging setup - get from environment variable, default to False
         self.print_log = os.getenv("FASTSAFETENSORS_DEBUG", "false").lower() == "true"
         self.log_prefix = f"PG{pg.rank() if pg is not None else 0}"
+
         fstcpp.set_gil_release(True)
 
     def _create_batches(self, pg) -> List[List[str]]:
@@ -305,7 +306,6 @@ class PipelineParallel:
             self._log_message(
                 f"Batch {batch.batch_id}: tensor key len: {len(batch.keys)}"
             )
-            # Consumer operation: extract tensors
             with TimingContext(
                 "get_tensor", self._log_message, batch.batch_id
             ) as timer:
@@ -323,8 +323,9 @@ class PipelineParallel:
             f"Batch {batch.batch_id} summary: "
             f"add_filenames={batch.add_filenames_time:.3f}ms, "
             f"copy_files={batch.copy_files_time:.3f}ms, "
-            f"get_tensor={get_tensor_time:.3f}ms, "
-            f"close={close_time:.3f}ms"
+            f"get_tensor_total={get_tensor_time:.3f}ms, "
+            f"close={close_time:.3f}ms, "
+            f"num_keys={len(batch.keys)}"
         )
         # sync
         if self.queue_size < 0 and self.consumer_processed is not None:
@@ -448,7 +449,7 @@ class ParallelLoader(PipelineParallel):
             nogds (bool): If True, turn off GDS and fallback to pread with bounce buffer.
             set_numa (bool): If True, set NUMA node for optimal memory allocation.
             debug_log (bool): Enable debug logs.
-            framework (str): Framework to use for tensor operations
+            framework (str): Framework to use for tensor operations.
         """
         loader = SafeTensorsFileLoader(
             pg,

--- a/fastsafetensors/threefs_loader.py
+++ b/fastsafetensors/threefs_loader.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, List, Optional
+
+from fastsafetensor_3fs_reader import extract_mount_point
+
+from . import cpp as fstcpp
+from .common import init_logger
+from .frameworks import get_framework_op
+from .loader import BaseSafeTensorsFileLoader, loaded_library
+from .parallel_loader import PipelineParallel
+
+logger = init_logger(__name__)
+
+
+class ThreeFSLoader(BaseSafeTensorsFileLoader):
+    """Load .safetensors files using 3FS USRBIO for high-performance I/O.
+
+    Args:
+        pg (Optional[Any]): Process group-like objects for distributed loading.
+        device (str): Target device where tensors will be loaded (CPU, CUDA, etc.).
+        mount_point (str): 3FS mount point path (e.g., "/mnt/3fs").
+        debug_log (bool): Enable detailed debug logging.
+        disable_cache (bool): Whether to disable caching of loaded tensors.
+        framework (str): Deep learning framework to use ("pytorch" or "paddle").
+        **kwargs: Additional arguments passed to BaseSafeTensorsFileLoader.
+
+    Examples:
+        >>> from fastsafetensors.threefs_loader import ThreeFSLoader
+        >>> loader = ThreeFSLoader(None, device="cuda:0", mount_point="/mnt/3fs")
+        >>> loader.add_filenames({0: ["/mnt/3fs/model.safetensors"]})
+        >>> bufs = loader.copy_files_to_device()
+        >>> tensor = bufs.get_tensor("weight")
+        >>> loader.close()
+    """
+
+    def __init__(
+        self,
+        pg: Optional[Any],
+        device: str = "cpu",
+        mount_point: str = "/mnt/3fs",
+        debug_log: bool = False,
+        disable_cache: bool = True,
+        framework: str = "pytorch",
+        **kwargs,
+    ):
+        self.framework = get_framework_op(framework)
+        self.pg = self.framework.get_process_group(pg)
+        self.device = self.framework.get_device(device, self.pg)
+
+        global loaded_library
+        if not loaded_library:
+            fstcpp.load_library_functions()
+            loaded_library = True
+        fstcpp.set_debug_log(debug_log)
+        super().__init__(
+            pg,
+            self.device,
+            copier_type="3fs",
+            set_numa=True,
+            disable_cache=disable_cache,
+            framework=framework,
+            mount_point=mount_point,
+            **kwargs,
+        )
+
+
+class ParallelThreeFSLoader(PipelineParallel):
+    """Parallel loader for .safetensors files using 3FS USRBIO.
+
+    This class provides pipeline-parallel loading of multiple safetensors files
+    using 3FS for high-performance I/O operations.
+
+    Args:
+        pg (Optional[Any]): Process group-like objects for distributed operations.
+        hf_weights_files (List[str]): List of safetensors files to load from 3FS.
+        mount_point (str): 3FS mount point path (e.g., "/mnt/3fs").
+        max_concurrent_producers (int): Maximum number of concurrent producer threads.
+        queue_size (int): Size of the queue for buffering loaded file batches.
+                         Default 0 for unbuffered behavior.
+        use_tqdm_on_load (bool): Enable progress bar during loading.
+        device (str): Target device for tensor loading.
+        debug_log (bool): Enable debug logs.
+        framework (str): Framework to use for tensor operations ("pytorch" or "paddle").
+        **kwargs: Additional arguments passed to the loader.
+
+    Examples:
+        >>> from fastsafetensors.threefs_loader import ParallelThreeFSLoader
+        >>> files = ["/mnt/3fs/model-00001.safetensors", "/mnt/3fs/model-00002.safetensors"]
+        >>> loader = ParallelThreeFSLoader(
+        ...     pg=None,
+        ...     hf_weights_files=files,
+        ...     mount_point="/mnt/3fs",
+        ...     device="cuda:0"
+        ... )
+        >>> for batch in loader:
+        ...     # Process batch
+        ...     pass
+    """
+
+    def __init__(
+        self,
+        pg: Optional[Any],
+        hf_weights_files: List[str],
+        max_concurrent_producers: int = 1,
+        queue_size: int = 0,
+        use_tqdm_on_load: bool = True,
+        device: str = "cpu",
+        debug_log: bool = False,
+        framework: str = "pytorch",
+        **kwargs,
+    ):
+        mount_point: str = extract_mount_point(hf_weights_files[0])
+
+        loader = ThreeFSLoader(
+            pg,
+            device=device,
+            mount_point=mount_point,
+            disable_cache=True,
+            debug_log=debug_log,
+            framework=framework,
+            **kwargs,
+        )
+
+        super().__init__(
+            pg,
+            loader,
+            hf_weights_files,
+            max_concurrent_producers,
+            queue_size,
+            use_tqdm_on_load,
+            **kwargs,
+        )

--- a/fastsafetensors/threefs_loader.py
+++ b/fastsafetensors/threefs_loader.py
@@ -2,8 +2,6 @@
 
 from typing import Any, List, Optional
 
-from fastsafetensor_3fs_reader import extract_mount_point
-
 from . import cpp as fstcpp
 from .common import init_logger
 from .frameworks import get_framework_op
@@ -110,6 +108,8 @@ class ParallelThreeFSLoader(PipelineParallel):
         framework: str = "pytorch",
         **kwargs,
     ):
+        from fastsafetensor_3fs_reader import extract_mount_point
+
         mount_point: str = extract_mount_point(hf_weights_files[0])
 
         loader = ThreeFSLoader(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dev = [
     "flake8==7.3.0",
     "mypy==1.19.1"
 ]
+threefs = [
+    "fastsafetensor-3fs-reader>=0.3.3",
+]
 
 [project.urls]
 Repository = "https://github.com/foundation-model-stack/fastsafetensors"

--- a/tests/threefs/conftest.py
+++ b/tests/threefs/conftest.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import types
+from typing import Any, Dict
+
+import pytest
+
+# Import fixtures from parent conftest so they are available in this directory
+from conftest import dev_init, input_files  # noqa: F401
+from threefs.mock_reader import MockFileReader
+from threefs.mock_reader import extract_mount_point as mock_extract_mount_point
+
+from fastsafetensors import SingleGroup
+from fastsafetensors import cpp as fstcpp
+from fastsafetensors.common import is_gpu_found
+from fastsafetensors.cpp import load_library_functions
+from fastsafetensors.frameworks import FrameworkOpBase, get_framework_op
+from fastsafetensors.st_types import Device
+
+
+@pytest.fixture(autouse=True, scope="session")
+def mock_3fs_reader():
+    """If fastsafetensor_3fs_reader is not installed, inject a mock module."""
+    try:
+        import fastsafetensor_3fs_reader  # noqa: F401
+    except ImportError:
+        mock_module = types.ModuleType("fastsafetensor_3fs_reader")
+        mock_module.ThreeFSFileReader = MockFileReader
+        mock_module.MockFileReader = MockFileReader
+        mock_module.extract_mount_point = mock_extract_mount_point
+        sys.modules["fastsafetensor_3fs_reader"] = mock_module
+    yield
+
+
+load_library_functions()
+FRAMEWORK = get_framework_op(os.getenv("TEST_FASTSAFETENSORS_FRAMEWORK", "please set"))
+
+
+def get_device(framework: FrameworkOpBase):
+    dev_is_gpu = is_gpu_found()
+    device = "cpu"
+    if dev_is_gpu:
+        if framework.get_name() == "pytorch":
+            device = "cuda:0"
+        elif framework.get_name() == "paddle":
+            device = "gpu:0"
+    return Device.from_str(device), dev_is_gpu
+
+
+def load_safetensors_file(
+    filename: str,
+    device: Device,
+    framework: FrameworkOpBase,
+) -> Dict[str, Any]:
+    if framework.get_name() == "pytorch":
+        from safetensors.torch import load_file
+    elif framework.get_name() == "paddle":
+        from safetensors.paddle import load_file
+    else:
+        raise Exception(f"unknown framework: {framework.get_name()}")
+    return load_file(filename, device.as_str())
+
+
+def tensors_equal(actual: Any, expected: Any, framework: FrameworkOpBase) -> bool:
+    """Compare raw tensors (torch.Tensor / paddle.Tensor) for equality."""
+    if framework.get_name() == "pytorch":
+        import torch
+
+        return bool(torch.all(actual.eq(expected)))
+    elif framework.get_name() == "paddle":
+        import paddle
+
+        return bool(paddle.all(actual == expected))
+    else:
+        raise Exception(f"unknown framework: {framework.get_name()}")
+
+
+@pytest.fixture(scope="session")
+def framework() -> FrameworkOpBase:
+    return FRAMEWORK
+
+
+@pytest.fixture(scope="function")
+def fstcpp_log() -> None:
+    fstcpp.set_debug_log(True)

--- a/tests/threefs/mock_reader.py
+++ b/tests/threefs/mock_reader.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mock file reader for CI tests. No 3FS/CUDA/external dependencies required."""
+
+import ctypes
+import os
+
+
+class MockFileReader:
+    """Local filesystem-backed mock reader for CI tests.
+
+    Uses os.pread for file I/O and ctypes.memmove for host memory copy.
+    dev_ptr is expected to point to host memory (cpu_malloc) in CI environments.
+    """
+
+    def __init__(self, mount_point: str = "", **kwargs) -> None:
+        self._fd_map: dict[str, int] = {}
+        self._mount_point = mount_point
+
+    def read_chunked(
+        self, path, dev_ptr, file_offset, total_length, chunk_size=0, **kwargs
+    ) -> int:
+        if path not in self._fd_map:
+            self._fd_map[path] = os.open(path, os.O_RDONLY)
+        fd = self._fd_map[path]
+        data = os.pread(fd, total_length, file_offset)
+        if dev_ptr != 0:
+            staging_buf = bytearray(data)
+            staging_ptr = ctypes.addressof(
+                (ctypes.c_char * len(staging_buf)).from_buffer(staging_buf)
+            )
+            ctypes.memmove(dev_ptr, staging_ptr, len(data))
+        return len(data)
+
+    def read_headers_batch(self, paths, num_threads=8):
+        return {}
+
+    def close(self) -> None:
+        for fd in self._fd_map.values():
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        self._fd_map.clear()
+
+
+def extract_mount_point(path: str) -> str:
+    """Fallback: return the directory containing the file."""
+    return os.path.dirname(os.path.abspath(path))

--- a/tests/threefs/test_parallel_threefs.py
+++ b/tests/threefs/test_parallel_threefs.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from typing import List
+
+import pytest
+from threefs.conftest import (
+    get_device,
+    load_safetensors_file,
+    tensors_equal,
+)
+
+from fastsafetensors import SingleGroup
+from fastsafetensors import cpp as fstcpp
+from fastsafetensors.frameworks import FrameworkOpBase
+from fastsafetensors.st_types import Device
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+EXAMPLES_DIR = os.path.join(REPO_ROOT, "examples")
+
+
+@pytest.fixture(scope="module")
+def example_files(framework) -> List[str]:
+    if framework.get_name() == "pytorch":
+        files = [
+            os.path.join(EXAMPLES_DIR, "a.safetensors"),
+            os.path.join(EXAMPLES_DIR, "b.safetensors"),
+        ]
+    elif framework.get_name() == "paddle":
+        files = [
+            os.path.join(EXAMPLES_DIR, "a_paddle.safetensors"),
+            os.path.join(EXAMPLES_DIR, "b_paddle.safetensors"),
+        ]
+    else:
+        raise Exception(f"unknown framework: {framework.get_name()}")
+    for f in files:
+        if not os.path.exists(f):
+            pytest.skip(f"Example file not found: {f}")
+    return files
+
+
+def test_parallel_single_file(fstcpp_log, example_files, framework):
+    from fastsafetensors.threefs_loader import ParallelThreeFSLoader
+
+    device, _ = get_device(framework)
+
+    loader = ParallelThreeFSLoader(
+        pg=SingleGroup(),
+        hf_weights_files=[example_files[0]],
+        device=device.as_str(),
+        debug_log=True,
+        framework=framework.get_name(),
+    )
+
+    expected = load_safetensors_file(example_files[0], device, framework)
+    loaded = {}
+    for key, tensor in loader.iterate_weights():
+        loaded[key] = tensor
+
+    assert set(loaded.keys()) == set(expected.keys())
+    for key, exp in expected.items():
+        assert tensors_equal(loaded[key], exp, framework), f"Tensor mismatch: {key}"
+
+    loader.close()
+    assert framework.get_mem_used() == 0
+
+
+def test_parallel_multiple_files(fstcpp_log, example_files, framework):
+    from fastsafetensors.threefs_loader import ParallelThreeFSLoader
+
+    device, _ = get_device(framework)
+
+    loader = ParallelThreeFSLoader(
+        pg=SingleGroup(),
+        hf_weights_files=example_files,
+        device=device.as_str(),
+        debug_log=True,
+        framework=framework.get_name(),
+    )
+
+    all_expected = {}
+    for f in example_files:
+        all_expected.update(load_safetensors_file(f, device, framework))
+
+    loaded = {}
+    for key, tensor in loader.iterate_weights():
+        loaded[key] = tensor
+
+    assert set(loaded.keys()) == set(all_expected.keys())
+    for key, exp in all_expected.items():
+        actual = loaded[key]
+        # Verify shape, dtype, and values
+        if framework.get_name() == "pytorch":
+            assert list(actual.shape) == list(exp.shape), f"Shape mismatch: {key}"
+            assert actual.dtype == exp.dtype, f"Dtype mismatch: {key}"
+        elif framework.get_name() == "paddle":
+            assert actual.shape == exp.shape, f"Shape mismatch: {key}"
+            assert actual.dtype == exp.dtype, f"Dtype mismatch: {key}"
+        assert tensors_equal(actual, exp, framework), f"Value mismatch: {key}"
+
+    loader.close()
+    assert framework.get_mem_used() == 0
+
+
+def test_parallel_close_and_memory_release(fstcpp_log, example_files, framework):
+    from fastsafetensors.threefs_loader import ParallelThreeFSLoader
+
+    device, _ = get_device(framework)
+
+    loader = ParallelThreeFSLoader(
+        pg=SingleGroup(),
+        hf_weights_files=example_files,
+        device=device.as_str(),
+        debug_log=True,
+        framework=framework.get_name(),
+    )
+
+    count = 0
+    for key, tensor in loader.iterate_weights():
+        assert tensor is not None
+        count += 1
+    assert count > 0
+
+    loader.close()
+    assert framework.get_mem_used() == 0
+    assert fstcpp.get_cpp_metrics().bounce_buffer_bytes == 0
+
+
+def test_parallel_close_without_iterate(fstcpp_log, example_files, framework):
+    from fastsafetensors.threefs_loader import ParallelThreeFSLoader
+
+    device, _ = get_device(framework)
+
+    loader = ParallelThreeFSLoader(
+        pg=SingleGroup(),
+        hf_weights_files=example_files,
+        device=device.as_str(),
+        debug_log=True,
+        framework=framework.get_name(),
+    )
+
+    loader.close()
+    assert framework.get_mem_used() == 0

--- a/tests/threefs/test_threefs.py
+++ b/tests/threefs/test_threefs.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+from threefs.conftest import get_device, load_safetensors_file
+
+from fastsafetensors import SafeTensorsMetadata, SingleGroup
+from fastsafetensors.copier import create_copier_constructor
+
+
+def test_threefs_copier_registered(fstcpp_log, framework):
+    device, _ = get_device(framework)
+    copier_fn = create_copier_constructor(
+        copier_type="3fs",
+        device=device,
+        mount_point="/tmp",
+    )
+    assert copier_fn is not None
+
+
+def test_ThreeFSFileCopier(fstcpp_log, input_files, framework):
+    from fastsafetensors.copier.threefs import (
+        ThreeFSFileCopier,
+        new_threefs_file_copier,
+    )
+
+    device, _ = get_device(framework)
+    input_file = input_files[0]
+    mount_point = os.path.dirname(input_file)
+
+    copier_fn = new_threefs_file_copier(device=device, mount_point=mount_point)
+    meta = SafeTensorsMetadata.from_file(input_file, framework)
+    copier = copier_fn(meta, device, framework)
+    assert isinstance(copier, ThreeFSFileCopier)
+
+    gbuf = copier.submit_io(False, 16 * 1024 * 1024 * 1024)
+    tensors = copier.wait_io(gbuf)
+
+    expected = load_safetensors_file(input_file, device, framework)
+    for key, exp in expected.items():
+        assert key in tensors, f"Missing tensor key: {key}"
+        assert framework.is_equal(tensors[key], exp), f"Tensor mismatch for key: {key}"
+
+    framework.free_tensor_memory(gbuf, device)
+    assert framework.get_mem_used() == 0
+
+
+def test_ThreeFSLoader(fstcpp_log, input_files, framework):
+    from fastsafetensors.threefs_loader import ThreeFSLoader
+
+    device, _ = get_device(framework)
+    input_file = input_files[0]
+    mount_point = os.path.dirname(input_file)
+
+    loader = ThreeFSLoader(
+        pg=SingleGroup(),
+        device=device.as_str(),
+        mount_point=mount_point,
+        debug_log=True,
+        framework=framework.get_name(),
+    )
+    loader.add_filenames({0: [input_file]})
+    bufs = loader.copy_files_to_device()
+
+    expected = load_safetensors_file(input_file, device, framework)
+    for key, exp in expected.items():
+        actual = bufs.get_tensor_wrapped(key)
+        assert framework.is_equal(actual, exp), f"Tensor mismatch for key: {key}"
+
+    bufs.close()
+    loader.close()
+    assert framework.get_mem_used() == 0
+
+
+def test_ThreeFSLoader_multiple_files(fstcpp_log, input_files, framework):
+    from fastsafetensors.threefs_loader import ThreeFSLoader
+
+    device, _ = get_device(framework)
+    mount_point = os.path.dirname(os.path.commonpath(input_files))
+
+    loader = ThreeFSLoader(
+        pg=SingleGroup(),
+        device=device.as_str(),
+        mount_point=mount_point,
+        debug_log=True,
+        framework=framework.get_name(),
+    )
+    loader.add_filenames({0: input_files})
+    bufs = loader.copy_files_to_device()
+
+    keys = loader.get_keys()
+    assert len(keys) > 0
+
+    for test_file in input_files:
+        expected = load_safetensors_file(test_file, device, framework)
+        for key, exp in expected.items():
+            actual = bufs.get_tensor_wrapped(key)
+            assert framework.is_equal(actual, exp), f"Tensor mismatch for key: {key}"
+
+    bufs.close()
+    loader.close()
+    assert framework.get_mem_used() == 0


### PR DESCRIPTION
## feat: add 3FS copier support

### Summary

Add support for [DeepSeek 3FS](https://github.com/deepseek-ai/3FS) USRBIO as a new copier backend for high-performance safetensors file loading. This enables fastsafetensors to leverage 3FS's zero-copy I/O and asynchronous read capabilities when loading model weights from 3FS-mounted filesystems.

resolve #55

### Motivation

3FS (Fire-Flyer File System) is a high-performance distributed filesystem designed for AI/ML workloads. By integrating 3FS USRBIO as a copier backend, fastsafetensors can achieve significantly higher I/O throughput when model weights are stored on 3FS-mounted paths, complementing the existing GDS and NoGDS copier backends.

### Changes

#### New Files

- **`fastsafetensors/copier/threefs.py`**: Core 3FS copier implementation
  - `ThreeFSFileCopier`: Implements `CopierInterface` using 3FS USRBIO for file reads
  - `new_threefs_file_copier()`: Factory function registered as `"3fs"` copier type via the copier registry
  - Uses `fastsafetensor-3fs-reader` package for the actual 3FS I/O operations

- **`fastsafetensors/threefs_loader.py`**: High-level loader APIs for 3FS
  - `ThreeFSLoader`: Single-file loader extending `BaseSafeTensorsFileLoader`
  - `ParallelThreeFSLoader`: Pipeline-parallel loader extending `PipelineParallel` for batch loading multiple safetensors files

#### Modified Files

- **`fastsafetensors/copier/gds.py`** & **`fastsafetensors/copier/nogds.py`**: Added `**kwargs` to `new_gds_file_copier()` and `new_nogds_file_copier()` for forward-compatible copier constructor signatures
- **`fastsafetensors/copier/__init__.py`**: Export `ThreeFSFileCopier`
- **`fastsafetensors/parallel_loader.py`**: Minor logging improvements (added `num_keys` to batch summary)
- **`pyproject.toml`**: Added `threefs` optional dependency group (`fastsafetensor-3fs-reader>=0.1.0`)

### Usage

```python
# Single file loading
from fastsafetensors.threefs_loader import ThreeFSLoader

loader = ThreeFSLoader(pg=None, device="cuda:0", mount_point="/mnt/3fs")
loader.add_filenames({0: ["/mnt/3fs/model.safetensors"]})
bufs = loader.copy_files_to_device()
tensor = bufs.get_tensor("weight")
loader.close()

# Parallel loading (iterate_weights interface)
from fastsafetensors.threefs_loader import ParallelThreeFSLoader

loader = ParallelThreeFSLoader(
    pg=None,
    hf_weights_files=["/mnt/3fs/model-00001.safetensors", "/mnt/3fs/model-00002.safetensors"],
    device="cuda:0",
)
for key, tensor in loader.iterate_weights():
    # Process each tensor
    pass
loader.close()
```

### Dependencies

This feature depends on the [`fastsafetensor-3fs-reader`](https://pypi.org/project/fastsafetensor-3fs-reader/) package, which is declared as an optional dependency:

```bash
pip install fastsafetensors[threefs]
```

If the 3FS reader package is not installed, the 3FS copier will not be available but all other functionality remains unaffected.

### Testing

Tests are provided under `tests/threefs/`, automatically skipped when `fastsafetensor_3fs_reader` is not available. To run locally with mock backend:

```bash
FASTSAFETENSORS_BACKEND=mock TEST_FASTSAFETENSORS_FRAMEWORK=pytorch \
    pytest tests/threefs/ -v
```

Tests also run in real 3FS environments without any special environment variable -- the skip condition checks whether `fastsafetensor_3fs_reader` is importable.

#### `tests/threefs/test_threefs.py` -- Unit tests for core 3FS components (uses gpt2 model data)
- `test_threefs_copier_registered`: Verifies `ThreeFSFileCopier` is registered in the copier registry
- `test_ThreeFSFileCopier`: Tests the copier `submit_io` + `wait_io` with tensor data verification
- `test_ThreeFSLoader`: Tests single-file loading via `ThreeFSLoader`
- `test_ThreeFSLoader_multiple_files`: Tests multi-file loading with full tensor correctness

#### `tests/threefs/test_parallel_threefs.py` -- Integration tests for `ParallelThreeFSLoader` (uses example safetensors files)
- `test_parallel_single_file`: Single-file iteration with tensor data correctness verification
- `test_parallel_multiple_files`: Multi-file iteration with shape, dtype, and value verification
- `test_parallel_close_and_memory_release`: Resource cleanup and bounce buffer release after full iteration
- `test_parallel_close_without_iterate`: Graceful cleanup when closing without iterating

All 8 tests pass (~1.7s).
