### PR TITLE
Add unified memory copier for DGX Spark / Grace Hopper

### DIFF
--- a/fastsafetensors/copier/__init__.py
+++ b/fastsafetensors/copier/__init__.py
@@ -9,3 +9,4 @@ from .registry import (
     create_copier_constructor,
     register_copier_constructor,
 )
+from .unified import UnifiedMemCopier

--- a/fastsafetensors/copier/gds.py
+++ b/fastsafetensors/copier/gds.py
@@ -205,6 +205,11 @@ def new_gds_file_copier(
 
     device_id = device.index if device.index is not None else 0
     if nogds:
+        # Prefer unified copier on systems with shared CPU/GPU memory
+        from .unified import is_unified_memory_system, new_unified_copier
+
+        if device_is_not_cpu and is_unified_memory_system():
+            return new_unified_copier(device)
         return new_nogds_file_copier(device, bbuf_size_kb, max_threads)
 
     reader = fstcpp.gds_file_reader(max_threads, device_is_not_cpu, device_id)

--- a/fastsafetensors/copier/unified.py
+++ b/fastsafetensors/copier/unified.py
@@ -68,6 +68,9 @@ class UnifiedMemCopier(CopierInterface):
             data_length,
         )
         if ret != 0:
+            self.framework.free_tensor_memory(gbuf, self.device)
+            self._pinned = None
+            self._file_tensor = None
             raise RuntimeError(
                 f"cudaMemcpyAsync failed with error {ret} " f"for {self.metadata.src}"
             )

--- a/fastsafetensors/copier/unified.py
+++ b/fastsafetensors/copier/unified.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unified memory copier for systems with shared CPU/GPU memory (DGX Spark, Grace Hopper).
+
+Uses mmap → pin_memory → cudaMemcpyAsync instead of the bounce buffer approach.
+On unified memory with ATS, pin_memory on mmap'd pages triggers kernel readahead
+and page pinning in a single optimized path, then async DMA transfers at full
+memory bandwidth.
+"""
+
+import os
+from typing import Dict, Optional
+
+import torch
+
+from .. import cpp as fstcpp
+from ..common import SafeTensorsMetadata
+from ..frameworks import FrameworkOpBase, TensorBase
+from ..st_types import Device, DeviceType, DType
+from .base import CopierInterface
+from .registry import CopierConstructFunc, register_copier_constructor
+
+
+class UnifiedMemCopier(CopierInterface):
+    """Copier using mmap → pin_memory → cudaMemcpyAsync for unified memory.
+
+    On systems where CPU and GPU share the same physical memory (DGX Spark,
+    Grace Hopper), this avoids the unnecessary bounce buffer used by NoGdsFileCopier.
+    The mmap + pin_memory path lets the kernel handle readahead and page pinning
+    in a single step, then async DMA copies at full memory bandwidth.
+    """
+
+    def __init__(
+        self,
+        metadata: SafeTensorsMetadata,
+        device: Device,
+        framework: FrameworkOpBase,
+    ):
+        self.metadata = metadata
+        self.device = device
+        self.framework = framework
+        self._file_tensor: Optional[torch.Tensor] = None
+        self._pinned: Optional[torch.Tensor] = None
+
+    def submit_io(
+        self, use_buf_register: bool, max_copy_block_size: int
+    ) -> fstcpp.gds_device_buffer:
+        data_length = self.metadata.size_bytes - self.metadata.header_length
+
+        # Allocate CUDA buffer via framework's allocator (proper lifecycle)
+        gbuf = self.framework.alloc_tensor_memory(data_length, self.device)
+
+        # mmap the file (lazy, no I/O yet)
+        file_tensor = torch.from_file(
+            self.metadata.src, size=self.metadata.size_bytes, dtype=torch.uint8
+        )
+        self._file_tensor = file_tensor
+        data_tensor = file_tensor[self.metadata.header_length :]
+
+        # pin_memory triggers kernel readahead + pins pages for DMA
+        pinned = data_tensor.pin_memory()
+        self._pinned = pinned
+
+        # Async DMA from pinned CPU → framework-allocated CUDA buffer
+        ret = fstcpp.memcpy_h2d_async(  # type: ignore[attr-defined]
+            gbuf.get_base_address(),
+            pinned.data_ptr(),
+            data_length,
+        )
+        if ret != 0:
+            raise RuntimeError(
+                f"cudaMemcpyAsync failed with error {ret} " f"for {self.metadata.src}"
+            )
+
+        return gbuf
+
+    def wait_io(
+        self,
+        gbuf: fstcpp.gds_device_buffer,
+        dtype: DType = DType.AUTO,
+        noalign: bool = False,
+    ) -> Dict[str, TensorBase]:
+        torch.cuda.synchronize()
+
+        # Alignment note: unlike the GDS copier, we only copy the data section
+        # (not the header) into gbuf, so gbuf starts at a CUDA-allocator-aligned
+        # address. The copy_start_offset=header_length cancels out in get_tensors'
+        # pointer arithmetic, giving correct offsets. No memmove fixup needed.
+        tensors = self.metadata.get_tensors(
+            gbuf, self.device, self.metadata.header_length, dtype=dtype
+        )
+
+        # Release mmap and pinned memory
+        self._pinned = None
+        self._file_tensor = None
+
+        return tensors
+
+
+def is_unified_memory_system() -> bool:
+    """Detect if this system has unified CPU/GPU memory.
+
+    Currently verified on DGX Spark (GB10). Other unified memory
+    platforms (Grace Hopper GH200) may also benefit but are untested.
+
+    Can be overridden via the FASTSAFETENSORS_UNIFIED_MEM environment
+    variable: set to "1" to force enable, "0" to force disable.
+    """
+    override = os.environ.get("FASTSAFETENSORS_UNIFIED_MEM")
+    if override is not None:
+        return override == "1"
+
+    if not torch.cuda.is_available():
+        return False
+
+    try:
+        name = torch.cuda.get_device_name(0).lower()
+        if "gb10" in name:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+@register_copier_constructor("unified")
+def new_unified_copier(device: Device, **kwargs) -> CopierConstructFunc:
+    """Factory function for UnifiedMemCopier.
+
+    Returns a constructor that creates UnifiedMemCopier instances.
+    """
+    from .nogds import load_library_func
+
+    load_library_func()
+
+    def construct_unified_copier(
+        metadata: SafeTensorsMetadata,
+        device: Device,
+        framework: FrameworkOpBase,
+    ) -> CopierInterface:
+        return UnifiedMemCopier(metadata, device, framework)
+
+    return construct_unified_copier

--- a/fastsafetensors/cpp/ext.cpp
+++ b/fastsafetensors/cpp/ext.cpp
@@ -41,6 +41,10 @@ static cudaError_t cpu_cudaMemcpy(void * dst, const void * src, size_t size, enu
     std::memcpy(dst, src, size);
     return cudaSuccess;
 }
+static cudaError_t cpu_cudaMemcpyAsync(void * dst, const void * src, size_t size, enum cudaMemcpyKind kind, cudaStream_t) {
+    std::memcpy(dst, src, size);
+    return cudaSuccess;
+}
 static cudaError_t cpu_cudaDeviceSynchronize() { return cudaSuccess; }
 static cudaError_t cpu_cudaHostAlloc(void ** p, size_t length, unsigned int) {
     if (posix_memalign(p, ALIGN, length) < 0) {
@@ -71,6 +75,7 @@ ext_funcs_t cpu_fns = ext_funcs_t {
     .cuFileHandleDeregister = cpu_cuFileHandleDeregister,
     .cuFileRead = nullptr,
     .cudaMemcpy = cpu_cudaMemcpy,
+    .cudaMemcpyAsync = cpu_cudaMemcpyAsync,
     .cudaDeviceSynchronize = cpu_cudaDeviceSynchronize,
     .cudaHostAlloc = cpu_cudaHostAlloc,
     .cudaFreeHost = cpu_cudaFreeHost,
@@ -141,6 +146,7 @@ static void load_library_functions() {
         }
         if (cuda_found) {
             mydlsym(&cuda_fns.cudaMemcpy, handle_cudart, "cudaMemcpy");
+            mydlsym(&cuda_fns.cudaMemcpyAsync, handle_cudart, "cudaMemcpyAsync");
             mydlsym(&cuda_fns.cudaDeviceSynchronize, handle_cudart, "cudaDeviceSynchronize");
             mydlsym(&cuda_fns.cudaHostAlloc, handle_cudart, "cudaHostAlloc");
             mydlsym(&cuda_fns.cudaFreeHost, handle_cudart, "cudaFreeHost");
@@ -812,6 +818,21 @@ cpp_metrics_t get_cpp_metrics() {
 
 // Bindings
 
+// Async host-to-device memcpy for unified memory copier
+static int memcpy_h2d_async(uintptr_t dst, uintptr_t src, size_t size) {
+    if (!cuda_fns.cudaMemcpyAsync) {
+        return -1;
+    }
+    cudaError_t err = cuda_fns.cudaMemcpyAsync(
+        reinterpret_cast<void *>(dst),
+        reinterpret_cast<const void *>(src),
+        size,
+        cudaMemcpyHostToDevice,
+        nullptr  // default stream
+    );
+    return static_cast<int>(err);
+}
+
 PYBIND11_MODULE(__MOD_NAME__, m)
 {
     // Initialize GIL release setting from environment variable on module load
@@ -846,6 +867,7 @@ PYBIND11_MODULE(__MOD_NAME__, m)
     m.def("gpu_malloc", &gpu_malloc);
     m.def("gpu_free", &gpu_free);
     m.def("load_library_functions", &load_library_functions);
+    m.def("memcpy_h2d_async", &memcpy_h2d_async);
     m.def("get_cpp_metrics", &get_cpp_metrics);
     m.def("set_gil_release", &set_gil_release);
     m.def("get_gil_release", &get_gil_release);

--- a/fastsafetensors/cpp/ext.hpp
+++ b/fastsafetensors/cpp/ext.hpp
@@ -43,6 +43,7 @@ enum cudaMemcpyKind { cudaMemcpyHostToDevice=1, cudaMemcpyDefault = 4 };
 #else
 enum cudaMemcpyKind { cudaMemcpyHostToDevice=2, cudaMemcpyDefault = 4 };
 #endif
+typedef void * cudaStream_t;
 
 
 typedef enum CUfileFeatureFlags {
@@ -205,6 +206,7 @@ typedef struct ext_funcs {
     void (*cuFileHandleDeregister)(CUfileHandle_t);
     ssize_t (*cuFileRead)(CUfileHandle_t, void *, size_t, off_t, off_t);
     cudaError_t (*cudaMemcpy)(void *, const void *, size_t, enum cudaMemcpyKind);
+    cudaError_t (*cudaMemcpyAsync)(void *, const void *, size_t, enum cudaMemcpyKind, cudaStream_t);
     cudaError_t (*cudaDeviceSynchronize)(void);
     cudaError_t (*cudaHostAlloc)(void **, size_t, unsigned int);
     cudaError_t (*cudaFreeHost)(void *);

--- a/fastsafetensors/loader.py
+++ b/fastsafetensors/loader.py
@@ -12,9 +12,10 @@ from .common import (
     set_debug,
 )
 from .copier import CopierConstructFunc, CopierType, create_copier_constructor
+from .copier.unified import is_unified_memory_system
 from .file_buffer import FilesBufferOnDevice
 from .frameworks import TensorBase, get_framework_op
-from .st_types import Device, DType
+from .st_types import Device, DeviceType, DType
 from .tensor_factory import LazyTensorFactory
 
 gl_set_numa = False
@@ -193,10 +194,16 @@ class SafeTensorsFileLoader(BaseSafeTensorsFileLoader):
         self.device = self.framework.get_device(device, self.pg)
 
         fstcpp.set_debug_log(debug_log)
-        if nogds:
-            copier_type = "nogds"
-        else:
+
+        if not nogds:
             copier_type = "gds"
+        elif self.device.type != DeviceType.CPU and is_unified_memory_system():
+            # When GDS is unavailable, prefer the unified copier on systems
+            # with shared CPU/GPU memory (e.g., DGX Spark) over the
+            # bounce-buffer nogds path.
+            copier_type = "unified"
+        else:
+            copier_type = "nogds"
         super().__init__(
             pg,
             self.device,

--- a/tests/test_fastsafetensors.py
+++ b/tests/test_fastsafetensors.py
@@ -13,6 +13,7 @@ from fastsafetensors import fastsafe_open
 from fastsafetensors.common import get_device_numa_node, is_gpu_found
 from fastsafetensors.copier.gds import GdsFileCopier
 from fastsafetensors.copier.nogds import NoGdsFileCopier
+from fastsafetensors.copier.unified import UnifiedMemCopier, is_unified_memory_system
 from fastsafetensors.dlpack import from_cuda_buffer
 from fastsafetensors.frameworks import FrameworkOpBase
 from fastsafetensors.st_types import Device, DeviceType, DType
@@ -359,6 +360,129 @@ def test_GdsFileCopier(fstcpp_log, input_files, framework) -> None:
     del reader
     assert framework.get_mem_used() == 0
     assert fstcpp.get_cpp_metrics().bounce_buffer_bytes == 0
+
+
+def _skip_if_not_pytorch(framework: FrameworkOpBase) -> None:
+    if framework.get_name() != "pytorch":
+        pytest.skip("UnifiedMemCopier uses torch.from_file / pin_memory directly")
+
+
+def test_UnifiedMemCopier(fstcpp_log, input_files, framework, monkeypatch) -> None:
+    print("test_UnifiedMemCopier")
+    _skip_if_not_pytorch(framework)
+    import ctypes
+
+    import torch
+
+    meta = SafeTensorsMetadata.from_file(input_files[0], framework)
+    device, dev_is_gpu = get_and_check_device(framework)
+
+    if not dev_is_gpu:
+        # Stand in for the CUDA-only primitives so the flow can run on CPU CI.
+        monkeypatch.setattr(torch.Tensor, "pin_memory", lambda self: self)
+
+        def fake_memcpy_h2d_async(dst, src, size):
+            ctypes.memmove(dst, src, size)
+            return 0
+
+        monkeypatch.setattr(fstcpp, "memcpy_h2d_async", fake_memcpy_h2d_async)
+        monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    copier = UnifiedMemCopier(meta, device, framework)
+    gbuf = copier.submit_io(False, 10 * 1024 * 1024 * 1024)
+    tensors = copier.wait_io(gbuf)
+    for key, exp in load_safetensors_file(input_files[0], device, framework).items():
+        actual = tensors[key]
+        assert framework.is_equal(actual, exp)
+    # Lifecycle: mmap + pinned references released in wait_io
+    assert copier._file_tensor is None
+    assert copier._pinned is None
+    framework.free_tensor_memory(gbuf, device)
+    assert framework.get_mem_used() == 0
+    assert fstcpp.get_cpp_metrics().bounce_buffer_bytes == 0
+
+
+def test_UnifiedMemCopier_cuda_error(
+    fstcpp_log, input_files, framework, monkeypatch
+) -> None:
+    print("test_UnifiedMemCopier_cuda_error")
+    _skip_if_not_pytorch(framework)
+    import torch
+
+    meta = SafeTensorsMetadata.from_file(input_files[0], framework)
+    device, _ = get_and_check_device(framework)
+
+    monkeypatch.setattr(torch.Tensor, "pin_memory", lambda self: self)
+    monkeypatch.setattr(fstcpp, "memcpy_h2d_async", lambda dst, src, size: 99)
+
+    copier = UnifiedMemCopier(meta, device, framework)
+    with pytest.raises(RuntimeError, match="99"):
+        copier.submit_io(False, 10 * 1024 * 1024 * 1024)
+    # gbuf must be freed and mmap/pin refs released on error
+    assert framework.get_mem_used() == 0
+    assert copier._file_tensor is None
+    assert copier._pinned is None
+
+
+@pytest.mark.parametrize(
+    "env,cuda_available,device_name,expected",
+    [
+        ("1", False, None, True),
+        ("0", True, "NVIDIA GB10 Tegra Blackwell", False),
+        (None, False, None, False),
+        (None, True, "NVIDIA A100-SXM4", False),
+        (None, True, "NVIDIA GB10 Tegra Blackwell", True),
+    ],
+)
+def test_is_unified_memory_system(
+    monkeypatch, env, cuda_available, device_name, expected
+) -> None:
+    import torch
+
+    if env is None:
+        monkeypatch.delenv("FASTSAFETENSORS_UNIFIED_MEM", raising=False)
+    else:
+        monkeypatch.setenv("FASTSAFETENSORS_UNIFIED_MEM", env)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: cuda_available)
+    if device_name is not None:
+        monkeypatch.setattr(torch.cuda, "get_device_name", lambda idx: device_name)
+    assert is_unified_memory_system() is expected
+
+
+@pytest.mark.parametrize(
+    "device_str,nogds,unified_env,expected_type",
+    [
+        ("cuda:0", True, "1", "unified"),  # opt-in on GPU
+        ("cuda:0", True, "0", "nogds"),  # opt-out on GPU
+        ("cpu", True, "1", "nogds"),  # CPU device skips unified even with env
+        ("cuda:0", False, "1", "gds"),  # nogds=False always picks gds
+    ],
+)
+def test_SafeTensorsFileLoader_copier_selection(
+    framework, monkeypatch, device_str, nogds, unified_env, expected_type
+) -> None:
+    _skip_if_not_pytorch(framework)
+    import fastsafetensors.loader as loader_mod
+
+    monkeypatch.setenv("FASTSAFETENSORS_UNIFIED_MEM", unified_env)
+
+    captured = {}
+
+    def spy_create_copier_constructor(copier_type, device, **kwargs):
+        captured["copier_type"] = copier_type
+        return lambda metadata, device, framework: None
+
+    monkeypatch.setattr(
+        loader_mod, "create_copier_constructor", spy_create_copier_constructor
+    )
+
+    SafeTensorsFileLoader(
+        pg=SingleGroup(),
+        device=device_str,
+        framework=framework.get_name(),
+        nogds=nogds,
+    )
+    assert captured["copier_type"] == expected_type
 
 
 def test_SafeTensorsFileLoader(fstcpp_log, input_files, framework) -> None:


### PR DESCRIPTION
New copier implementation optimized for systems with shared CPU/GPU memory (DGX Spark GB10). Uses mmap → pin_memory → cudaMemcpyAsync instead of the pread + bounce buffer path.

On DGX Spark, pin_memory on mmap'd pages triggers kernel readahead and page pinning in a single optimized step, then async DMA transfers at full memory bandwidth (~12 GB/s measured vs ~0.9 GB/s with nogds).

Auto-detected in SafeTensorsFileLoader: on unified memory systems, the "unified" copier type is selected regardless of the nogds flag, since both GDS (no RDMA) and nogds (bounce buffer) are suboptimal when CPU and GPU share the same physical memory.

Registered as copier type "unified" via the copier registry.