### PR TITLE
[ROCm]Use vendor-agnostic check is nogds copier

### DIFF
--- a/fastsafetensors/copier/nogds.py
+++ b/fastsafetensors/copier/nogds.py
@@ -86,7 +86,9 @@ def new_nogds_file_copier(
     load_library_func()
     device_is_not_cpu = device.type != DeviceType.CPU
     if device_is_not_cpu and not is_gpu_found():
-        raise Exception("[FAIL] libcudart.so does not exist")
+        raise Exception(
+            "[FAIL] GPU runtime library not found (expected libcudart.so or libamdhip64.so)"
+        )
 
     device_id = device.index if device.index is not None else 0
     nogds_reader = fstcpp.nogds_file_reader(

--- a/fastsafetensors/copier/nogds.py
+++ b/fastsafetensors/copier/nogds.py
@@ -4,7 +4,7 @@ import os
 from typing import Dict, List
 
 from .. import cpp as fstcpp
-from ..common import SafeTensorsMetadata
+from ..common import SafeTensorsMetadata, is_gpu_found
 from ..frameworks import FrameworkOpBase, TensorBase
 from ..st_types import Device, DeviceType, DType
 from .base import CopierInterface
@@ -85,7 +85,7 @@ def new_nogds_file_copier(
 ) -> CopierConstructFunc:
     load_library_func()
     device_is_not_cpu = device.type != DeviceType.CPU
-    if device_is_not_cpu and not fstcpp.is_cuda_found():
+    if device_is_not_cpu and is_gpu_found():
         raise Exception("[FAIL] libcudart.so does not exist")
 
     device_id = device.index if device.index is not None else 0

--- a/fastsafetensors/copier/nogds.py
+++ b/fastsafetensors/copier/nogds.py
@@ -85,7 +85,7 @@ def new_nogds_file_copier(
 ) -> CopierConstructFunc:
     load_library_func()
     device_is_not_cpu = device.type != DeviceType.CPU
-    if device_is_not_cpu and is_gpu_found():
+    if device_is_not_cpu and not is_gpu_found():
         raise Exception("[FAIL] libcudart.so does not exist")
 
     device_id = device.index if device.index is not None else 0


### PR DESCRIPTION
# Motivation
This issue is found in sglang model loading, where nogds is used for fastsafetensor backend. I use the recommended way to install fastsafetensor, but met `libcudart.so does not exsit` error. 

# Detail
This PR replaced the cuda only check with vendoer-agnostic check in copier `fastsafetensors/copier/nogds.py`