### PR TITLE
[ROCm] Remove hipify-perl build dependency, enable manylinux wheel builds

### DIFF
--- a/fastsafetensors/cpp/cuda_compat.h
+++ b/fastsafetensors/cpp/cuda_compat.h
@@ -1,34 +1,61 @@
 // SPDX-License-Identifier: Apache-2.0
 /*
  * CUDA/HIP compatibility layer for fastsafetensors
- * Minimal compatibility header - only defines what hipify-perl doesn't handle
+ *
+ * All GPU functions are loaded at runtime via dlopen()/dlsym() — no CUDA or
+ * HIP headers are included and no GPU runtime library is linked at build time.
+ * This header provides the two things the preprocessor can handle that dlsym
+ * string literals cannot: the library filename and the per-platform symbol names.
  */
 
 #ifndef __CUDA_COMPAT_H__
 #define __CUDA_COMPAT_H__
 
-// Platform detection - this gets hipified to check __HIP_PLATFORM_AMD__
 #ifdef __HIP_PLATFORM_AMD__
   #ifndef USE_ROCM
     #define USE_ROCM
   #endif
-  // Note: We do NOT include <hip/hip_runtime.h> here to avoid compile-time dependencies.
-  // Instead, we dynamically load the ROCm runtime library (libamdhip64.so) at runtime
-  // using dlopen(), just like we do for CUDA (libcudart.so).
-  // Minimal types are defined in ext.hpp.
-#else
-  // For CUDA platform, we also avoid including headers and define minimal types in ext.hpp
 #endif
 
-// Runtime library name - hipify-perl doesn't change string literals
+// Runtime library loaded via dlopen()
 #ifdef USE_ROCM
   #define GPU_RUNTIME_LIB "libamdhip64.so"
 #else
   #define GPU_RUNTIME_LIB "libcudart.so"
 #endif
 
-// Custom function pointer names that hipify-perl doesn't recognize
-// These are our own naming in ext_funcs struct, not standard CUDA API
+// Symbol names passed to dlsym().
+// Replaces the hipify-perl string-literal transformation so the source
+// compiles for either backend without any external build-time tooling.
+#ifdef USE_ROCM
+  #define GPU_SYM_GET_DEVICE_COUNT      "hipGetDeviceCount"
+  #define GPU_SYM_MEMCPY                "hipMemcpy"
+  #define GPU_SYM_MEMCPY_ASYNC          "hipMemcpyAsync"
+  #define GPU_SYM_DEVICE_SYNCHRONIZE    "hipDeviceSynchronize"
+  #define GPU_SYM_HOST_ALLOC            "hipHostMalloc"
+  #define GPU_SYM_FREE_HOST             "hipHostFree"
+  #define GPU_SYM_DEVICE_GET_PCI_BUS_ID "hipDeviceGetPCIBusId"
+  #define GPU_SYM_DEVICE_MALLOC         "hipMalloc"
+  #define GPU_SYM_DEVICE_FREE           "hipFree"
+  #define GPU_SYM_DRIVER_GET_VERSION    "hipDriverGetVersion"
+  #define GPU_SYM_DEVICE_GET_ATTRIBUTE  "hipDeviceGetAttribute"
+  #define GPU_SYM_SET_DEVICE            "hipSetDevice"
+#else
+  #define GPU_SYM_GET_DEVICE_COUNT      "cudaGetDeviceCount"
+  #define GPU_SYM_MEMCPY                "cudaMemcpy"
+  #define GPU_SYM_MEMCPY_ASYNC          "cudaMemcpyAsync"
+  #define GPU_SYM_DEVICE_SYNCHRONIZE    "cudaDeviceSynchronize"
+  #define GPU_SYM_HOST_ALLOC            "cudaHostAlloc"
+  #define GPU_SYM_FREE_HOST             "cudaFreeHost"
+  #define GPU_SYM_DEVICE_GET_PCI_BUS_ID "cudaDeviceGetPCIBusId"
+  #define GPU_SYM_DEVICE_MALLOC         "cudaMalloc"
+  #define GPU_SYM_DEVICE_FREE           "cudaFree"
+  #define GPU_SYM_DRIVER_GET_VERSION    "cudaDriverGetVersion"
+  #define GPU_SYM_DEVICE_GET_ATTRIBUTE  "cudaDeviceGetAttribute"
+  #define GPU_SYM_SET_DEVICE            "cudaSetDevice"
+#endif
+
+// Internal struct field name aliases for ROCm builds
 #ifdef USE_ROCM
   #define cudaDeviceMalloc hipDeviceMalloc
   #define cudaDeviceFree hipDeviceFree

--- a/fastsafetensors/cpp/ext.cpp
+++ b/fastsafetensors/cpp/ext.cpp
@@ -86,7 +86,6 @@ ext_funcs_t cpu_fns = ext_funcs_t {
 ext_funcs_t cuda_fns;
 
 static bool cuda_found = false;
-static bool is_hip_runtime = false;  // Track if we loaded HIP (not auto-hipified)
 static bool cufile_found = false;
 
 static int cufile_ver = 0;
@@ -124,38 +123,34 @@ static void load_library_functions() {
 
     void* handle_cudart = dlopen(cudartLib, mode);
     if (handle_cudart) {
-        mydlsym(&cudaGetDeviceCount, handle_cudart, "cudaGetDeviceCount");
+        mydlsym(&cudaGetDeviceCount, handle_cudart, GPU_SYM_GET_DEVICE_COUNT);
         if (cudaGetDeviceCount) {
             int count;
             if (cudaGetDeviceCount(&count) != cudaSuccess) {
                 count = 0; // why cudaGetDeviceCount returns non-zero for errors?
             }
             cuda_found = count > 0;
-            // Detect if we loaded HIP runtime (ROCm) vs CUDA runtime
-            if (cuda_found && std::string(cudartLib).find("hip") != std::string::npos) {
-                is_hip_runtime = true;
-            }
             if (init_log) {
-                fprintf(stderr, "[DEBUG] device count=%d, cuda_found=%d, is_hip_runtime=%d\n", count, cuda_found, is_hip_runtime);
+                fprintf(stderr, "[DEBUG] device count=%d, cuda_found=%d\n", count, cuda_found);
             }
         } else {
             cuda_found = false;
             if (init_log) {
-                fprintf(stderr, "[DEBUG] No cudaGetDeviceCount, fallback!\n");
+                fprintf(stderr, "[DEBUG] No %s, fallback!\n", GPU_SYM_GET_DEVICE_COUNT);
             }
         }
         if (cuda_found) {
-            mydlsym(&cuda_fns.cudaMemcpy, handle_cudart, "cudaMemcpy");
-            mydlsym(&cuda_fns.cudaMemcpyAsync, handle_cudart, "cudaMemcpyAsync");
-            mydlsym(&cuda_fns.cudaDeviceSynchronize, handle_cudart, "cudaDeviceSynchronize");
-            mydlsym(&cuda_fns.cudaHostAlloc, handle_cudart, "cudaHostAlloc");
-            mydlsym(&cuda_fns.cudaFreeHost, handle_cudart, "cudaFreeHost");
-            mydlsym(&cuda_fns.cudaDeviceGetPCIBusId, handle_cudart, "cudaDeviceGetPCIBusId");
-            mydlsym(&cuda_fns.cudaDeviceMalloc, handle_cudart, "cudaMalloc");
-            mydlsym(&cuda_fns.cudaDeviceFree, handle_cudart, "cudaFree");
-            mydlsym(&cuda_fns.cudaDriverGetVersion, handle_cudart, "cudaDriverGetVersion");
-            mydlsym(&cuda_fns.cudaDeviceGetAttribute, handle_cudart, "cudaDeviceGetAttribute");
-            mydlsym(&cuda_fns.cudaSetDevice, handle_cudart, "cudaSetDevice");
+            mydlsym(&cuda_fns.cudaMemcpy, handle_cudart, GPU_SYM_MEMCPY);
+            mydlsym(&cuda_fns.cudaMemcpyAsync, handle_cudart, GPU_SYM_MEMCPY_ASYNC);
+            mydlsym(&cuda_fns.cudaDeviceSynchronize, handle_cudart, GPU_SYM_DEVICE_SYNCHRONIZE);
+            mydlsym(&cuda_fns.cudaHostAlloc, handle_cudart, GPU_SYM_HOST_ALLOC);
+            mydlsym(&cuda_fns.cudaFreeHost, handle_cudart, GPU_SYM_FREE_HOST);
+            mydlsym(&cuda_fns.cudaDeviceGetPCIBusId, handle_cudart, GPU_SYM_DEVICE_GET_PCI_BUS_ID);
+            mydlsym(&cuda_fns.cudaDeviceMalloc, handle_cudart, GPU_SYM_DEVICE_MALLOC);
+            mydlsym(&cuda_fns.cudaDeviceFree, handle_cudart, GPU_SYM_DEVICE_FREE);
+            mydlsym(&cuda_fns.cudaDriverGetVersion, handle_cudart, GPU_SYM_DRIVER_GET_VERSION);
+            mydlsym(&cuda_fns.cudaDeviceGetAttribute, handle_cudart, GPU_SYM_DEVICE_GET_ATTRIBUTE);
+            mydlsym(&cuda_fns.cudaSetDevice, handle_cudart, GPU_SYM_SET_DEVICE);
             bool success = cuda_fns.cudaMemcpy && cuda_fns.cudaDeviceSynchronize;
             success = success && cuda_fns.cudaHostAlloc && cuda_fns.cudaFreeHost;
             success = success && cuda_fns.cudaDeviceGetPCIBusId && cuda_fns.cudaDeviceMalloc;
@@ -253,14 +248,6 @@ bool is_cuda_found()
 bool cuda_not_available()
 {
     return false;  // On ROCm, CUDA is never available
-}
-
-// Separate function for checking HIP runtime detection (not hipified)
-// On CUDA: checks if HIP runtime was detected
-// On ROCm: not used (is_cuda_found gets hipified to is_hip_found)
-bool check_hip_runtime()
-{
-    return is_hip_runtime;
 }
 
 bool is_cufile_found()
@@ -837,20 +824,13 @@ PYBIND11_MODULE(__MOD_NAME__, m)
 {
     // Initialize GIL release setting from environment variable on module load
     init_gil_release_from_env();
-    // Export both is_cuda_found and is_hip_found on all platforms
-    // Use string concatenation to prevent hipify from converting the export names
+    // Export both is_cuda_found and is_hip_found on all platforms.
 #ifdef USE_ROCM
-    // On ROCm after hipify:
-    // - is_cuda_found() becomes is_hip_found(), so export it as "is_hip_found"
-    // - Export cuda_not_available() as "is_cuda_found" (CUDA not available on ROCm)
-    m.def(("is_" "cuda" "_found"), &cuda_not_available);  // Returns false on ROCm
-    m.def(("is_" "hip" "_found"), &is_cuda_found);  // hipified to is_hip_found, returns hip status
+    m.def("is_cuda_found", &cuda_not_available);
+    m.def("is_hip_found", &is_cuda_found);
 #else
-    // On CUDA:
-    // - is_cuda_found() checks for CUDA
-    // - check_hip_runtime() checks if HIP runtime was loaded
-    m.def(("is_" "cuda" "_found"), &is_cuda_found);
-    m.def(("is_" "hip" "_found"), &check_hip_runtime);
+    m.def("is_cuda_found", &is_cuda_found);
+    m.def("is_hip_found", &cuda_not_available);
 #endif
     m.def("is_cufile_found", &is_cufile_found);
     m.def("cufile_version", &cufile_version);

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import re
-import shutil
-import subprocess
-from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
@@ -13,138 +9,18 @@ from setuptools.command.build_ext import build_ext
 def detect_platform():
     """
     Detect if we're on NVIDIA CUDA or AMD ROCm platform.
-
-    Returns:
-        tuple: (platform_type, rocm_version, rocm_path)
-            platform_type: 'cuda' or 'rocm'
-            rocm_version: ROCm version string (e.g., '7.0.1') or None
-            rocm_path: Path to ROCm installation or None
+    ROCm is detected by the presence of ROCM_PATH (default /opt/rocm).
     """
-    # Safely get ROCM_PATH from environment variables, or use the default
     rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
-
-    # Check if ROCm is available
     if rocm_path and os.path.exists(rocm_path):
-        # Detect ROCm version
-        rocm_version = None
-        version_file = os.path.join(rocm_path, ".info", "version")
-        if os.path.exists(version_file):
-            with open(version_file, "r") as f:
-                rocm_version = f.read().strip()
-        else:
-            # Try to extract version from path
-            match = re.search(r"rocm[-/](\d+\.\d+(?:\.\d+)?)", rocm_path)
-            if match:
-                rocm_version = match.group(1)
-
         print(f"Detected ROCm platform at {rocm_path}")
-        if rocm_version:
-            print(f"ROCm version: {rocm_version}")
-        return ("rocm", rocm_version, rocm_path)
+        return "rocm"
 
-    # Check for CUDA
-    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
-    if not cuda_home:
-        # Try to find nvcc
-        nvcc_path = shutil.which("nvcc")
-        if nvcc_path:
-            cuda_home = os.path.dirname(os.path.dirname(nvcc_path))
-
-    if cuda_home and os.path.exists(cuda_home):
-        print(f"Detected CUDA platform at {cuda_home}")
-        return ("cuda", None, None)
-
-    # Default to CUDA if nothing detected
-    print("No GPU platform detected, defaulting to CUDA")
-    return ("cuda", None, None)
+    print("Detected CUDA platform (default)")
+    return "cuda"
 
 
-def hipify_source_files(rocm_path):
-    """
-    Automatically hipify CUDA source files to HIP using hipify-perl from ROCm.
-    The cuda_compat.h header handles what hipify doesn't convert.
-
-    Args:
-        rocm_path: Path to ROCm installation
-
-    Returns:
-        list: Paths to hipified source files
-    """
-    cpp_dir = Path("fastsafetensors/cpp").resolve()
-    hip_dir = cpp_dir / "hip"
-
-    # Create hip/ subdirectory if it doesn't exist
-    hip_dir.mkdir(exist_ok=True)
-
-    # Find hipify-perl in ROCm installation
-    hipify_perl = os.path.join(rocm_path, "bin", "hipify-perl")
-    if not os.path.exists(hipify_perl):
-        raise RuntimeError(
-            f"hipify-perl not found at {hipify_perl}. "
-            f"Please ensure ROCm is properly installed at {rocm_path}"
-        )
-
-    # Files to hipify
-    source_files = [
-        ("ext.cpp", "ext.cpp"),
-        ("ext.hpp", "ext.hpp"),
-    ]
-
-    print(f"Hipifying files using hipify-perl from {hipify_perl}:")
-    hipified_files = []
-
-    for src_name, dst_name in source_files:
-        src_path = cpp_dir / src_name
-        dst_path = hip_dir / dst_name
-
-        print(f"  - {src_path} -> {dst_path}")
-
-        try:
-            # Run hipify-perl: hipify-perl input.cpp -o output.cpp
-            result = subprocess.run(
-                [hipify_perl, str(src_path), "-o", str(dst_path)],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-            print(f"    Successfully hipified: {src_name}")
-            hipified_files.append(str(dst_path))
-
-            # Print any warnings from hipify-perl
-            if result.stderr:
-                print(f"    hipify-perl output: {result.stderr.strip()}")
-
-            # Post-process: Replace cuda_compat.h with hip_compat.h
-            # hipify-perl doesn't convert custom header names
-            with open(dst_path, "r") as f:
-                content = f.read()
-            content = content.replace(
-                '#include "cuda_compat.h"', '#include "hip_compat.h"'
-            )
-            with open(dst_path, "w") as f:
-                f.write(content)
-            print(f"    Post-processed: cuda_compat.h -> hip_compat.h")
-
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(
-                f"Failed to hipify {src_path}:\n"
-                f"stdout: {e.stdout}\n"
-                f"stderr: {e.stderr}"
-            ) from e
-
-    # Copy cuda_compat.h to hip directory as hip_compat.h
-    # (hipify converts the include statement from cuda_compat.h to hip_compat.h)
-    cuda_compat = cpp_dir / "cuda_compat.h"
-    hip_compat = hip_dir / "hip_compat.h"
-    shutil.copy2(cuda_compat, hip_compat)
-    print(f"Copied {cuda_compat} -> {hip_compat}")
-
-    return hipified_files
-
-
-def MyExtension(
-    name, sources, mod_name, platform_type, rocm_path=None, *args, **kwargs
-):
+def MyExtension(name, sources, mod_name, platform_type, *args, **kwargs):
     import pybind11
 
     pybind11_path = os.path.dirname(pybind11.__file__)
@@ -153,87 +29,23 @@ def MyExtension(
     kwargs["libraries"] = ["stdc++"]
     kwargs["include_dirs"] = kwargs.get("include_dirs", []) + [
         f"{pybind11_path}/include"
-    ]  # for pybind11/pybind11.h
+    ]
     kwargs["language"] = "c++"
-
-    # https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes
     kwargs["extra_compile_args"] = ["-fvisibility=hidden", "-std=c++17"]
 
-    # Platform-specific configuration
-    if platform_type == "rocm" and rocm_path:
-        # ROCm/HIP configuration
-        kwargs["define_macros"].append(("__HIP_PLATFORM_AMD__", "1"))
-        kwargs["libraries"].append("amdhip64")
-        kwargs["library_dirs"] = [f"{rocm_path}/lib"]
-        kwargs["include_dirs"].append(f"{rocm_path}/include")
-        kwargs["extra_compile_args"].append("-D__HIP_PLATFORM_AMD__")
-        kwargs["extra_link_args"] = [f"-L{rocm_path}/lib", "-lamdhip64"]
+    if platform_type == "rocm":
+        # Define platform macros so cuda_compat.h selects the ROCm symbol names.
+        # No ROCm headers or libraries are needed at build time — the runtime
+        # library (libamdhip64.so) is loaded via dlopen() when the module runs.
+        kwargs["define_macros"] += [
+            ("__HIP_PLATFORM_AMD__", "1"),
+            ("USE_ROCM", "1"),
+        ]
 
     return Extension(name, sources, *args, **kwargs)
 
 
-class CustomBuildExt(build_ext):
-    """Custom build_ext to handle automatic hipification for ROCm platforms"""
-
-    def run(self):
-        # Detect platform
-        platform_type, rocm_version, rocm_path = detect_platform()
-
-        # Store platform info
-        self.platform_type = platform_type
-        self.rocm_version = rocm_version
-        self.rocm_path = rocm_path
-
-        #  Configure build based on platform
-        if platform_type == "rocm" and rocm_path:
-            print("=" * 60)
-            print("Building for AMD ROCm platform")
-            if rocm_version:
-                print(f"ROCm version: {rocm_version}")
-            print("=" * 60)
-
-            # Hipify sources
-            hipify_source_files(rocm_path)
-
-            # Update extension sources to use hipified files
-            for ext in self.extensions:
-                new_sources = []
-                for src in ext.sources:
-                    if "fastsafetensors/cpp/ext.cpp" in src:
-                        # torch.utils.hipify creates files in hip/ subdirectory
-                        new_sources.append(
-                            src.replace(
-                                "fastsafetensors/cpp/ext.cpp",
-                                "fastsafetensors/cpp/hip/ext.cpp",
-                            )
-                        )
-                    else:
-                        new_sources.append(src)
-                ext.sources = new_sources
-
-                # Update include dirs to include hip/ subdirectory
-                ext.include_dirs.append("fastsafetensors/cpp/hip")
-
-                # Update extension with ROCm-specific settings
-                ext.define_macros.append(("__HIP_PLATFORM_AMD__", "1"))
-                ext.define_macros.append(("USE_ROCM", "1"))
-                ext.libraries.append("amdhip64")
-                ext.library_dirs = [f"{rocm_path}/lib"]
-                ext.include_dirs.append(f"{rocm_path}/include")
-                ext.extra_compile_args.append("-D__HIP_PLATFORM_AMD__")
-                ext.extra_compile_args.append("-DUSE_ROCM")
-                ext.extra_link_args = [f"-L{rocm_path}/lib", "-lamdhip64"]
-        else:
-            print("=" * 60)
-            print("Building for NVIDIA CUDA platform")
-            print("=" * 60)
-
-        # Continue with normal build
-        build_ext.run(self)
-
-
-# Detect platform for package_data
-platform_type, _, rocm_path_detected = detect_platform()
+platform_type = detect_platform()
 package_data_patterns = ["*.hpp", "*.h", "cpp.pyi"]
 
 setup(
@@ -247,15 +59,11 @@ setup(
     package_data={"fastsafetensors.cpp": package_data_patterns},
     ext_modules=[
         MyExtension(
-            name=f"fastsafetensors.cpp",
+            name="fastsafetensors.cpp",
             sources=["fastsafetensors/cpp/ext.cpp"],
             include_dirs=["fastsafetensors/cpp"],
             mod_name="cpp",
             platform_type=platform_type,
-            rocm_path=rocm_path_detected,
         )
     ],
-    cmdclass={
-        "build_ext": CustomBuildExt,
-    },
 )


### PR DESCRIPTION
# Motivation

The ROCm wheel currently requires `hipify-perl` (from the ROCm toolchain) at build time, which forces the build to run inside a ROCm container and produces a `linux_x86_64` wheel instead of a portable `manylinux` wheel.

The only job `hipify-perl` was doing here was transforming `dlsym` string literals — e.g. `"cudaMemcpy"` → `"hipMemcpy"` — so the dynamic loader looks up the right symbol in `libamdhip64.so` at runtime. This is something the C preprocessor can handle directly.

This directly addresses the request in the review of #34:
> "Fastsafetensors dynamically load shared libraries at run time, not compile time. I want you to try doing the same on ROCm library. If that is possible, general ROCm users can avoid building code by themselves, can just use downloaded pip packages."

# Changes

**`cuda_compat.h`** — adds `GPU_SYM_*` macros for each `dlsym` symbol name, selecting CUDA or HIP names based on `USE_ROCM`:

```c
#ifdef USE_ROCM
  #define GPU_SYM_MEMCPY  "hipMemcpy"
  // ...
#else
  #define GPU_SYM_MEMCPY  "cudaMemcpy"
  // ...
#endif
```

**`ext.cpp`** — replaces the 12 hardcoded `dlsym` string literals with the new macros. Also removes `is_hip_runtime` and `check_hip_runtime()`: these were meant to detect at runtime whether a HIP library had been loaded (by checking if the `.so` filename contained `"hip"`), but on CUDA builds `cudartLib` is always `"libcudart.so"`, so the flag was never set and `check_hip_runtime()` always returned `false`. With platform selected at compile time this runtime detection is unnecessary. The CUDA-path `is_hip_found` export now uses the existing `cuda_not_available` function directly. The pybind export strings are also simplified from the split-literal concatenation trick (which existed to prevent `hipify-perl` from transforming them) to plain string literals.

**`setup.py`** — removes `hipify_source_files()` and `CustomBuildExt` entirely. For ROCm builds, only `__HIP_PLATFORM_AMD__` and `USE_ROCM` need to be defined via `define_macros` — no ROCm headers, no `libamdhip64.so` link at build time. Also removes the `rocm_version` detection logic (version was only used by `CustomBuildExt` for build logging, which is now gone) and the unused `import re`.

# Result

- ROCm wheel builds in a standard `manylinux` container with no ROCm toolchain installed
- Both CUDA and ROCm wheels can be published to PyPI as proper `manylinux` wheels
- Runtime behavior is identical — `libamdhip64.so` is still loaded via `dlopen()` on ROCm systems
