### PR TITLE
Add F4 (float4_e2m1fn_x2) and F8_E8M0 (float8_e8m0fnu) dtype support

### DIFF
--- a/fastsafetensors/common.py
+++ b/fastsafetensors/common.py
@@ -100,7 +100,7 @@ class SafeTensorsMetadata:
             nelements = 1
             for sh in t.shape:
                 nelements *= sh
-            nbytes = nelements * framework.get_dtype_size(t.dtype)
+            nbytes = int(nelements * framework.get_dtype_size(t.dtype))
             if (e - s) != nbytes:
                 raise Exception(
                     f"validate(tensor {k}): TensorInvalidInfo, e-s={e-s}, nbytes={nbytes}, src={src}"
@@ -195,16 +195,25 @@ class SafeTensorsMetadata:
                 - copy_start_offset
             )
             disk_dtype = self.framework.as_workaround_dtype(t.dtype)
+            dl_shape, dl_strides = self.framework.get_storage_shape(
+                t.dtype, t.shape, t.strides
+            )
             dl_tensor = from_cuda_buffer(
                 dst_dev_ptr,
-                t.shape,
-                t.strides,
+                dl_shape,
+                dl_strides,
                 disk_dtype,
                 device,
             )
             t2 = self.framework.from_dlpack(dl_tensor, device, disk_dtype)
             if disk_dtype != t.dtype:
                 t2 = t2.view(t.dtype)
+            # For packed sub-byte dtypes, reshape to the framework-native shape.
+            # e.g. F4 (float4_e2m1fn_x2): safetensors shape counts FP4 values,
+            # but PyTorch shape counts packed pairs (2 FP4 per byte).
+            native_shape = self.framework.get_native_shape(t.dtype, t.shape)
+            if native_shape != t.shape:
+                t2 = t2.reshape(native_shape)
 
             if dtype != DType.AUTO and dtype != t.dtype:
                 if self.framework.get_dtype_size(dtype) > self.framework.get_dtype_size(

--- a/fastsafetensors/dlpack.py
+++ b/fastsafetensors/dlpack.py
@@ -89,6 +89,14 @@ class c_DLDataType(ctypes.Structure):
         DType.F32: (kDLFloat, 32, 1),
         DType.F64: (kDLFloat, 64, 1),
         DType.BF16: (kDLBfloat, 16, 1),
+        # F8_E8M0 is an unsigned 8-bit scale format (torch.float8_e8m0fnu).
+        # DLPack has no float8 type code, so we expose it as opaque uint8
+        # bytes — consistent with the U8 workaround used for NCCL ops.
+        DType.F8_E8M0: (kDLUInt, 8, 1),
+        # F4 is packed FP4 (torch.float4_e2m1fn_x2): two 4-bit values per byte.
+        # DLPack has no sub-byte type code, so we expose it as opaque uint8
+        # bytes — consistent with the U8 workaround used for NCCL ops.
+        DType.F4: (kDLUInt, 8, 1),
     }
 
 

--- a/fastsafetensors/frameworks/__init__.py
+++ b/fastsafetensors/frameworks/__init__.py
@@ -45,6 +45,15 @@ class TensorBase:
     def __getitem__(self, _val) -> "TensorBase":
         pass
 
+    def reshape(self, shape: List[int]) -> "TensorBase":
+        """Reshape the tensor.  Default implementation raises NotImplementedError.
+        Frameworks that support packed sub-byte dtypes (e.g. F4) must override
+        this to handle shape adjustment after buffer loading.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement reshape()"
+        )
+
 
 T = TypeVar("T", bound=TensorBase)
 
@@ -127,7 +136,14 @@ class FrameworkOpBase(ABC, Generic[T, K]):
         pass
 
     @abstractmethod
-    def get_dtype_size(self, dtype: DType) -> int:
+    def get_dtype_size(self, dtype: DType) -> float:
+        """Return the number of bytes per logical element for this dtype.
+
+        For packed sub-byte types (e.g. F4 / float4_e2m1fn_x2, where two
+        FP4 values share a single byte), this returns a fractional value
+        (0.5 for F4).  Callers should use ``int(nelements *
+        get_dtype_size(dtype))`` when computing byte counts.
+        """
         pass
 
     @abstractmethod
@@ -145,6 +161,29 @@ class FrameworkOpBase(ABC, Generic[T, K]):
     @abstractmethod
     def as_workaround_dtype(self, dtype: DType) -> DType:
         pass
+
+    def get_storage_shape(
+        self, dtype: DType, shape: List[int], strides: List[int]
+    ) -> "tuple[List[int], List[int]]":
+        """Return the (shape, strides) to use for the workaround-dtype DLPack
+        tensor when loading from a device buffer.
+
+        For most dtypes this is just (shape, strides).  Packed sub-byte dtypes
+        (e.g. F4 / float4_e2m1fn_x2) store multiple logical values per byte;
+        the safetensors shape counts logical values while DLPack / PyTorch work
+        in bytes, so the shape must be collapsed to a flat byte count.
+        """
+        return shape, strides
+
+    def get_native_shape(self, dtype: DType, st_shape: List[int]) -> List[int]:
+        """Return the framework-native tensor shape for a safetensors tensor.
+
+        For most dtypes this matches *st_shape* exactly.  For packed sub-byte
+        dtypes the safetensors shape counts logical (sub-byte) elements while
+        the framework counts packed storage units (bytes), so the shape is
+        compressed by the packing ratio.
+        """
+        return st_shape
 
     @abstractmethod
     def get_process_group(self, pg: Optional[Any]) -> ProcessGroupBase:

--- a/fastsafetensors/frameworks/_torch.py
+++ b/fastsafetensors/frameworks/_torch.py
@@ -29,12 +29,18 @@ dtype_convert: Dict[DType, Any] = {
 need_workaround_dtypes: Dict[DType, DType] = {
     DType.F8_E5M2: DType.I8,
     DType.F8_E4M3: DType.I8,
+    DType.F8_E8M0: DType.U8,
+    DType.F4: DType.U8,
 }
 
 if hasattr(torch, "float8_e5m2"):
     dtype_convert[DType.F8_E5M2] = torch.float8_e5m2
 if hasattr(torch, "float8_e4m3fn"):
     dtype_convert[DType.F8_E4M3] = torch.float8_e4m3fn
+if hasattr(torch, "float8_e8m0fnu"):
+    dtype_convert[DType.F8_E8M0] = torch.float8_e8m0fnu
+if hasattr(torch, "float4_e2m1fn_x2"):
+    dtype_convert[DType.F4] = torch.float4_e2m1fn_x2
 if hasattr(torch, "uint16"):
     dtype_convert[DType.U16] = torch.uint16
 if hasattr(torch, "uint32"):
@@ -87,6 +93,9 @@ class TorchTensor(TensorBase):
     def __getitem__(self, _val) -> "TorchTensor":
         return TorchTensor(self.device, self.dtype, self.real_tensor[_val])
 
+    def reshape(self, shape: List[int]) -> "TorchTensor":
+        return TorchTensor(self.device, self.dtype, self.real_tensor.reshape(shape))
+
 
 def _needs_fp8_cast() -> bool:
     """Check if FP8 NCCL ops need a bf16 workaround (pre-sm90 GPUs)."""
@@ -97,7 +106,7 @@ def _needs_fp8_cast() -> bool:
 
 
 def _is_fp8(dtype: DType) -> bool:
-    return dtype in (DType.F8_E5M2, DType.F8_E4M3)
+    return dtype in (DType.F8_E5M2, DType.F8_E4M3, DType.F8_E8M0)
 
 
 @dataclass
@@ -211,8 +220,9 @@ class TorchOp(FrameworkOpBase[TorchTensor, TorchProcessGroup]):
     def get_empty_tensor(
         self, shape: List[int], dtype: DType, device: Device
     ) -> TorchTensor:
+        native_shape = self.get_native_shape(dtype, shape)
         dst = torch.empty(
-            size=shape, dtype=dtype_convert[dtype], device=device.as_str()
+            size=native_shape, dtype=dtype_convert[dtype], device=device.as_str()
         )
         return TorchTensor(device, dtype, dst)
 
@@ -220,8 +230,13 @@ class TorchOp(FrameworkOpBase[TorchTensor, TorchProcessGroup]):
         ts = [tensor.real_tensor for tensor in tensors]
         return TorchTensor(tensors[0].device, tensors[0].dtype, torch.cat(ts, dim=dim))
 
-    def get_dtype_size(self, dtype: DType) -> int:
-        return dtype_convert[dtype].itemsize
+    def get_dtype_size(self, dtype: DType) -> float:
+        if dtype == DType.F4:
+            # float4_e2m1fn_x2 packs two 4-bit values into one byte.
+            # safetensors stores shape in FP4-element count, so the byte
+            # size per logical element is 0.5.
+            return 0.5
+        return float(dtype_convert[dtype].itemsize)
 
     def from_dlpack(self, dl_tensor: Any, device: Device, dtype: DType) -> TorchTensor:
         t = torch.from_dlpack(dl_tensor)
@@ -252,6 +267,32 @@ class TorchOp(FrameworkOpBase[TorchTensor, TorchProcessGroup]):
         if dtype in need_workaround_dtypes:
             return need_workaround_dtypes[dtype]
         return dtype
+
+    def get_storage_shape(
+        self, dtype: DType, shape: List[int], strides: List[int]
+    ) -> "tuple[List[int], List[int]]":
+        size = self.get_dtype_size(dtype)
+        if size < 1.0:
+            # Packed sub-byte dtype: collapse to flat byte count so the
+            # workaround-dtype DLPack tensor doesn't overread the buffer.
+            import math
+
+            nbytes = int(math.prod(shape) * size)
+            return [nbytes], [1]
+        return shape, strides
+
+    def get_native_shape(self, dtype: DType, st_shape: List[int]) -> List[int]:
+        size = self.get_dtype_size(dtype)
+        if size < 1.0:
+            # safetensors counts logical sub-byte elements; PyTorch counts
+            # packed storage units (bytes). Compress the last dimension.
+            import math
+
+            ratio = int(round(1.0 / size))  # e.g. 2 for F4 (2 FP4 per byte)
+            if len(st_shape) > 1:
+                return list(st_shape[:-1]) + [st_shape[-1] // ratio]
+            return [int(math.prod(st_shape) * size)]
+        return st_shape
 
     def get_process_group(self, pg: Optional[Any]) -> TorchProcessGroup:
         if pg is not None:

--- a/fastsafetensors/st_types.py
+++ b/fastsafetensors/st_types.py
@@ -58,4 +58,6 @@ class DType(Enum):
     BF16 = "BF16"
     F8_E5M2 = "F8_E5M2"
     F8_E4M3 = "F8_E4M3"
+    F8_E8M0 = "F8_E8M0"
+    F4 = "F4"
     AUTO = "AUTO"

--- a/tests/test_fastsafetensors.py
+++ b/tests/test_fastsafetensors.py
@@ -662,6 +662,65 @@ def test_float8_e4m3fn_to_int8(fstcpp_log, tmp_dir, framework) -> None:
     _test_type(tmp_dir, DType.F8_E4M3, device, framework, DType.I8)
 
 
+def test_float4_e2m1fn_x2(fstcpp_log, tmp_dir, framework) -> None:
+    """Test bit-exact round-trip for F4 (torch.float4_e2m1fn_x2).
+
+    F4 is a packed FP4 format (two 4-bit values per byte, dtype string "F4" in
+    safetensors) used for expert weight matrices in models like DeepSeek V4-Flash.
+
+    The safetensors shape is in FP4-element count while torch.float4_e2m1fn_x2
+    counts packed byte-pairs, so the PyTorch shape has half as many elements in
+    the last dimension.  fastsafetensors handles the shape conversion internally.
+    """
+    if framework.get_name() != "pytorch":
+        pytest.skip("F4 is only available in PyTorch")
+        return
+    import torch
+
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        pytest.skip("torch.float4_e2m1fn_x2 requires PyTorch 2.10+")
+        return
+    device, _ = get_and_check_device(framework)
+    filename = os.path.join(tmp_dir, "f4.safetensors")
+    # F4 tensors cannot be created via randn/cast; create via uint8 view.
+    # Shape [8, 16] in FP4-element terms = shape [8, 8] in float4_e2m1fn_x2.
+    u8 = torch.arange(64, dtype=torch.uint8, device=device.as_str()).reshape(8, 8)
+    t0 = u8.view(torch.float4_e2m1fn_x2)
+    save_safetensors_file({"a": t0}, filename, {"fst": "sample"}, framework)
+    t_ref = load_safetensors_file(filename, device, framework)
+    with fastsafe_open(
+        filenames=[filename],
+        nogds=True,
+        device=device.as_str(),
+        framework=framework.get_name(),
+        debug_log=True,
+    ) as f:
+        for key in f.keys():
+            t1 = f.get_tensor_wrapped(key).clone().detach()
+            assert framework.is_equal(t1, t_ref[key])
+    assert framework.get_mem_used() == 0
+    assert fstcpp.get_cpp_metrics().bounce_buffer_bytes == 0
+
+
+def test_float8_e8m0fnu(fstcpp_log, tmp_dir, framework) -> None:
+    """Test bit-exact round-trip for F8_E8M0 (torch.float8_e8m0fnu).
+
+    F8_E8M0 is an unsigned 8-bit exponent-only format used as per-tile
+    quantization scales in models like DeepSeek V4-Flash.  It has no mantissa
+    bits, so ordinary randn -> cast is safe for creating test tensors.
+    """
+    if framework.get_name() != "pytorch":
+        pytest.skip("F8_E8M0 is only available in PyTorch")
+        return
+    import torch
+
+    if not hasattr(torch, "float8_e8m0fnu"):
+        pytest.skip("torch.float8_e8m0fnu requires PyTorch 2.5+")
+        return
+    device, _ = get_and_check_device(framework)
+    _test_type(tmp_dir, DType.F8_E8M0, device, framework)
+
+
 def test_cpp_metrics(fstcpp_log, framework) -> None:
     device, _ = get_and_check_device(framework)
     exp_length = 0


### PR DESCRIPTION
## Summary

Adds support for two dtypes used by modern mixed-precision models (DeepSeek V4-Flash, DeepSeek V3, etc.) that currently cause `add_filenames()` to fail:

- **F8_E8M0** (`torch.float8_e8m0fnu`, PyTorch 2.5+): unsigned 8-bit exponent-only format used for per-tile quantization scales. One byte per element. Straightforward addition — same storage size as F8_E4M3.

- **F4** (`torch.float4_e2m1fn_x2`, PyTorch 2.10+): packed FP4 format, two 4-bit values per byte. safetensors stores the shape in FP4-element count while PyTorch `float4_e2m1fn_x2` counts packed pairs (one byte each). This requires shape adjustment on load.

Without these, any safetensors file containing F4 or F8_E8M0 tensors raises:
```
ValueError: 'F8_E8M0' is not a valid DType
ValueError: 'F4' is not a valid DType
```

## Changes

**`fastsafetensors/st_types.py`**
- Add `F4` and `F8_E8M0` to `DType` enum

**`fastsafetensors/frameworks/_torch.py`**
- Map `DType.F8_E8M0` → `torch.float8_e8m0fnu` (guarded by `hasattr`)
- Map `DType.F4` → `torch.float4_e2m1fn_x2` (guarded by `hasattr`)
- Add `U8` NCCL workaround for both (NCCL has no float8_e8m0/float4 support)
- `get_dtype_size()` returns `0.5` for F4 (two FP4 values per byte)
- `get_storage_shape()`: collapses packed sub-byte shapes to flat byte count for DLPack so the workaround-dtype view doesn't overread the buffer
- `get_native_shape()`: converts safetensors FP4-element shape to PyTorch packed-pair shape
- `get_empty_tensor()`: uses `get_native_shape()` for correct allocation shape
- `TorchTensor.reshape()`: needed by `common.py` after DLPack import

**`fastsafetensors/frameworks/__init__.py`**
- `get_dtype_size()` return type: `int` → `float` (to accommodate `0.5` for F4)
- `get_storage_shape()` added (default: identity — no change for existing dtypes)
- `get_native_shape()` added (default: identity — no change for existing dtypes)
- `TensorBase.reshape()` added (default: `NotImplementedError`)

**`fastsafetensors/dlpack.py`**
- F4 and F8_E8M0: mapped as opaque `(kDLUInt, 8, 1)` — consistent with their U8 workaround

**`fastsafetensors/common.py`**
- Validation: `nbytes = int(nelements * get_dtype_size())` — safe for fractional sizes
- `get_tensors()`: uses `get_storage_shape()` / `get_native_shape()` for packed dtypes

**`tests/test_fastsafetensors.py`**
- `test_float8_e8m0fnu`: bit-exact round-trip via `_test_type`
- `test_float4_e2m1fn_x2`: bit-exact round-trip (uses uint8 view, since randn/cast don't support float4)

## F4 shape handling detail

safetensors stores an F4 weight of logical shape `[2048, 4096]` (8M FP4 values) as 4 MiB (0.5 bytes per FP4 value). `torch.float4_e2m1fn_x2` represents paired values: `[2048, 4096]` in that dtype would be 8 MiB — wrong. The correct PyTorch shape is `[2048, 2048]` (4M packed pairs = 4 MiB).

`get_storage_shape()` handles DLPack by using a flat `[4194304]` uint8 shape (avoids buffer overread). `get_native_shape()` then reshapes to `[2048, 2048]` after the view. `get_empty_tensor()` also uses `get_native_shape()` so broadcast/scatter allocations are correctly sized.

## Validation

Tested against DeepSeek V4-Flash MP=2 safetensors shards (~82 GiB each) containing all six dtypes (BF16, F32, F4, F8_E4M3, F8_E8M0, I64). With this PR:
- `add_filenames()` succeeds on V4-Flash shards
- All tensors load bit-exactly vs `safetensors.torch.load_file`
- 41 tests pass (39 existing + 2 new), zero regressions

## Notes

- `get_storage_shape()` and `get_native_shape()` default to identity on `FrameworkOpBase`, so non-PyTorch frameworks (e.g. Paddle) are unaffected unless they add their own F4/F8_E8M0 dtype mappings.
- F8_E8M0 requires PyTorch ≥ 2.5; F4 requires PyTorch ≥ 2.10. Both additions are guarded by `hasattr()` so older PyTorch versions still work for all currently-supported dtypes.