### PR TITLE
Add support for F4 and F8_E8M0 dtypes

### DIFF
--- a/fastsafetensors/common.py
+++ b/fastsafetensors/common.py
@@ -179,7 +179,7 @@ class SafeTensorsMetadata:
             nelements = 1
             for sh in t.shape:
                 nelements *= sh
-            nbytes = nelements * framework.get_dtype_size(t.dtype)
+            nbytes = int(nelements * framework.get_dtype_size(t.dtype))
             if (e - s) != nbytes:
                 raise Exception(
                     f"validate(tensor {k}): TensorInvalidInfo, e-s={e-s}, nbytes={nbytes}, src={src}"
@@ -290,16 +290,25 @@ class SafeTensorsMetadata:
                 - copy_start_offset
             )
             disk_dtype = self.framework.as_workaround_dtype(t.dtype)
+            dl_shape, dl_strides = self.framework.get_storage_shape(
+                t.dtype, t.shape, t.strides
+            )
             dl_tensor = from_cuda_buffer(
                 dst_dev_ptr,
-                t.shape,
-                t.strides,
+                dl_shape,
+                dl_strides,
                 disk_dtype,
                 device,
             )
             t2 = self.framework.from_dlpack(dl_tensor, device, disk_dtype)
             if disk_dtype != t.dtype:
                 t2 = t2.view(t.dtype)
+            # For packed sub-byte dtypes, reshape to the framework-native shape.
+            # e.g. F4 (float4_e2m1fn_x2): safetensors shape counts FP4 values,
+            # but PyTorch shape counts packed pairs (2 FP4 per byte).
+            native_shape = self.framework.get_native_shape(t.dtype, t.shape)
+            if native_shape != t.shape:
+                t2 = t2.reshape(native_shape)
 
             if dtype != DType.AUTO and dtype != t.dtype:
                 if self.framework.get_dtype_size(dtype) > self.framework.get_dtype_size(

--- a/fastsafetensors/dlpack.py
+++ b/fastsafetensors/dlpack.py
@@ -89,6 +89,14 @@ class c_DLDataType(ctypes.Structure):
         DType.F32: (kDLFloat, 32, 1),
         DType.F64: (kDLFloat, 64, 1),
         DType.BF16: (kDLBfloat, 16, 1),
+        # F8_E8M0 is an unsigned 8-bit scale format (torch.float8_e8m0fnu).
+        # DLPack has no float8 type code, so we expose it as opaque uint8
+        # bytes — consistent with the U8 workaround used for NCCL ops.
+        DType.F8_E8M0: (kDLUInt, 8, 1),
+        # F4 is packed FP4 (torch.float4_e2m1fn_x2): two 4-bit values per byte.
+        # DLPack has no sub-byte type code, so we expose it as opaque uint8
+        # bytes — consistent with the U8 workaround used for NCCL ops.
+        DType.F4: (kDLUInt, 8, 1),
     }
 
 

--- a/fastsafetensors/frameworks/__init__.py
+++ b/fastsafetensors/frameworks/__init__.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Generic, List, Optional, TypeVar
+from typing import Any, Generic, List, Optional, Tuple, TypeVar
 
 from ..cpp import gds_device_buffer
 from ..st_types import Device, DType
@@ -44,6 +44,13 @@ class TensorBase:
     @abstractmethod
     def __getitem__(self, _val) -> "TensorBase":
         pass
+
+    def reshape(self, shape: List[int]) -> "TensorBase":
+        """Reshape the tensor.  Default implementation raises NotImplementedError.
+        Frameworks that support packed sub-byte dtypes (e.g. F4) must override
+        this to handle shape adjustment after buffer loading.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not implement reshape()")
 
 
 T = TypeVar("T", bound=TensorBase)
@@ -127,7 +134,14 @@ class FrameworkOpBase(ABC, Generic[T, K]):
         pass
 
     @abstractmethod
-    def get_dtype_size(self, dtype: DType) -> int:
+    def get_dtype_size(self, dtype: DType) -> float:
+        """Return the number of bytes per logical element for this dtype.
+
+        For packed sub-byte types (e.g. F4 / float4_e2m1fn_x2, where two
+        FP4 values share a single byte), this returns a fractional value
+        (0.5 for F4).  Callers should use ``int(nelements *
+        get_dtype_size(dtype))`` when computing byte counts.
+        """
         pass
 
     @abstractmethod
@@ -145,6 +159,39 @@ class FrameworkOpBase(ABC, Generic[T, K]):
     @abstractmethod
     def as_workaround_dtype(self, dtype: DType) -> DType:
         pass
+
+    def get_storage_shape(
+        self, dtype: DType, shape: List[int], strides: List[int]
+    ) -> "tuple[List[int], List[int]]":
+        """Return the (shape, strides) to use for the workaround-dtype DLPack
+        tensor when loading from a device buffer.
+
+        For most dtypes this is just (shape, strides).  Packed sub-byte dtypes
+        (e.g. F4 / float4_e2m1fn_x2) store multiple logical values per byte;
+        the safetensors shape counts logical values while DLPack / PyTorch work
+        in bytes, so the shape must be collapsed to a flat byte count.
+        """
+        return shape, strides
+
+    def get_native_shape(self, dtype: DType, st_shape: List[int]) -> List[int]:
+        """Return the framework-native tensor shape for a safetensors tensor.
+
+        For most dtypes this matches *st_shape* exactly.  For packed sub-byte
+        dtypes the safetensors shape counts logical (sub-byte) elements while
+        the framework counts packed storage units (bytes), so the shape is
+        compressed by the packing ratio.
+        """
+        return st_shape
+
+    def get_native_slices(
+        self, dtype: DType, st_shape: List[int], slices: Tuple
+    ) -> Tuple:
+        """Return slices to apply to a framework-native tensor.
+
+        For most dtypes this is just *slices*.  Frameworks with packed
+        sub-byte dtypes can translate logical slices into storage-unit slices.
+        """
+        return slices
 
     @abstractmethod
     def get_process_group(self, pg: Optional[Any]) -> ProcessGroupBase:

--- a/fastsafetensors/frameworks/_torch.py
+++ b/fastsafetensors/frameworks/_torch.py
@@ -7,7 +7,7 @@ except ImportError as e:
     raise ImportError("could not import torch. Please install it.") from e
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..common import SingleGroup
 from ..cpp import cpu_free, cpu_malloc, gds_device_buffer
@@ -29,12 +29,18 @@ dtype_convert: Dict[DType, Any] = {
 need_workaround_dtypes: Dict[DType, DType] = {
     DType.F8_E5M2: DType.I8,
     DType.F8_E4M3: DType.I8,
+    DType.F8_E8M0: DType.U8,
+    DType.F4: DType.U8,
 }
 
 if hasattr(torch, "float8_e5m2"):
     dtype_convert[DType.F8_E5M2] = torch.float8_e5m2
 if hasattr(torch, "float8_e4m3fn"):
     dtype_convert[DType.F8_E4M3] = torch.float8_e4m3fn
+if hasattr(torch, "float8_e8m0fnu"):
+    dtype_convert[DType.F8_E8M0] = torch.float8_e8m0fnu
+if hasattr(torch, "float4_e2m1fn_x2"):
+    dtype_convert[DType.F4] = torch.float4_e2m1fn_x2
 if hasattr(torch, "uint16"):
     dtype_convert[DType.U16] = torch.uint16
 if hasattr(torch, "uint32"):
@@ -87,6 +93,9 @@ class TorchTensor(TensorBase):
     def __getitem__(self, _val) -> "TorchTensor":
         return TorchTensor(self.device, self.dtype, self.real_tensor[_val])
 
+    def reshape(self, shape: List[int]) -> "TorchTensor":
+        return TorchTensor(self.device, self.dtype, self.real_tensor.reshape(shape))
+
 
 def _needs_fp8_cast() -> bool:
     """Check if FP8 NCCL ops need a bf16 workaround (pre-sm90 GPUs)."""
@@ -97,7 +106,17 @@ def _needs_fp8_cast() -> bool:
 
 
 def _is_fp8(dtype: DType) -> bool:
-    return dtype in (DType.F8_E5M2, DType.F8_E4M3)
+    return dtype in (DType.F8_E5M2, DType.F8_E4M3, DType.F8_E8M0)
+
+
+def _needs_uint8_view(dtype: DType) -> bool:
+    """NCCL has no native collective for F8_E8M0 or F4. Reinterpret as uint8.
+
+    Same byte width, bitwise-transparent for collective ops (broadcast/scatter/
+    send/recv). Bypasses NCCL's dtype dispatch without an alloc or value
+    conversion.
+    """
+    return dtype in (DType.F8_E8M0, DType.F4)
 
 
 @dataclass
@@ -112,7 +131,11 @@ class TorchProcessGroup(ProcessGroupBase[TorchTensor]):
 
     def broadcast(self, dst: TorchTensor, rank: int) -> None:
         if self.real_pg:
-            if _is_fp8(dst.dtype) and _needs_fp8_cast():
+            if _needs_uint8_view(dst.dtype):
+                dist.broadcast(
+                    dst.real_tensor.view(torch.uint8), rank, group=self.real_pg
+                )
+            elif _is_fp8(dst.dtype) and _needs_fp8_cast():
                 buf = dst.real_tensor.to(torch.bfloat16)
                 dist.broadcast(buf, rank, group=self.real_pg)
                 dst.real_tensor.copy_(buf.to(dst.real_tensor.dtype))
@@ -129,7 +152,15 @@ class TorchProcessGroup(ProcessGroupBase[TorchTensor]):
         src: int,
     ) -> None:
         if self.real_pg:
-            if _is_fp8(dst.dtype) and _needs_fp8_cast():
+            if _needs_uint8_view(dst.dtype):
+                sl = [t.real_tensor.view(torch.uint8) for t in scatter_list]
+                dist.scatter(
+                    dst.real_tensor.view(torch.uint8),
+                    scatter_list=sl,
+                    src=src,
+                    group=self.real_pg,
+                )
+            elif _is_fp8(dst.dtype) and _needs_fp8_cast():
                 sl = [t.real_tensor.to(torch.bfloat16) for t in scatter_list]
                 buf = dst.real_tensor.to(torch.bfloat16)
                 dist.scatter(buf, scatter_list=sl, src=src, group=self.real_pg)
@@ -150,7 +181,14 @@ class TorchProcessGroup(ProcessGroupBase[TorchTensor]):
         tag: int,
     ):
         if self.real_pg:
-            if _is_fp8(t.dtype) and _needs_fp8_cast():
+            if _needs_uint8_view(t.dtype):
+                dist.send(
+                    t.real_tensor.view(torch.uint8),
+                    dst_rank,
+                    group=self.real_pg,
+                    tag=tag,
+                )
+            elif _is_fp8(t.dtype) and _needs_fp8_cast():
                 buf = t.real_tensor.to(torch.bfloat16)
                 dist.send(buf, dst_rank, group=self.real_pg, tag=tag)
                 del buf
@@ -166,7 +204,14 @@ class TorchProcessGroup(ProcessGroupBase[TorchTensor]):
         tag: int,
     ):
         if self.real_pg:
-            if _is_fp8(t.dtype) and _needs_fp8_cast():
+            if _needs_uint8_view(t.dtype):
+                dist.recv(
+                    t.real_tensor.view(torch.uint8),
+                    src_rank,
+                    group=self.real_pg,
+                    tag=tag,
+                )
+            elif _is_fp8(t.dtype) and _needs_fp8_cast():
                 buf = t.real_tensor.to(torch.bfloat16)
                 dist.recv(buf, src_rank, group=self.real_pg, tag=tag)
                 t.real_tensor.copy_(buf.to(t.real_tensor.dtype))
@@ -211,17 +256,28 @@ class TorchOp(FrameworkOpBase[TorchTensor, TorchProcessGroup]):
     def get_empty_tensor(
         self, shape: List[int], dtype: DType, device: Device
     ) -> TorchTensor:
+        native_shape = self.get_native_shape(dtype, shape)
         dst = torch.empty(
-            size=shape, dtype=dtype_convert[dtype], device=device.as_str()
+            size=native_shape, dtype=dtype_convert[dtype], device=device.as_str()
         )
         return TorchTensor(device, dtype, dst)
 
     def concat_tensors(self, tensors: List[TorchTensor], dim: int) -> TorchTensor:
+        dtype = tensors[0].dtype
+        if _needs_uint8_view(dtype):
+            ts = [tensor.real_tensor.view(torch.uint8) for tensor in tensors]
+            t = torch.cat(ts, dim=dim).view(dtype_convert[dtype])
+            return TorchTensor(tensors[0].device, dtype, t)
         ts = [tensor.real_tensor for tensor in tensors]
-        return TorchTensor(tensors[0].device, tensors[0].dtype, torch.cat(ts, dim=dim))
+        return TorchTensor(tensors[0].device, dtype, torch.cat(ts, dim=dim))
 
-    def get_dtype_size(self, dtype: DType) -> int:
-        return dtype_convert[dtype].itemsize
+    def get_dtype_size(self, dtype: DType) -> float:
+        if dtype == DType.F4:
+            # float4_e2m1fn_x2 packs two 4-bit values into one byte.
+            # safetensors stores shape in FP4-element count, so the byte
+            # size per logical element is 0.5.
+            return 0.5
+        return float(dtype_convert[dtype].itemsize)
 
     def from_dlpack(self, dl_tensor: Any, device: Device, dtype: DType) -> TorchTensor:
         t = torch.from_dlpack(dl_tensor)
@@ -252,6 +308,82 @@ class TorchOp(FrameworkOpBase[TorchTensor, TorchProcessGroup]):
         if dtype in need_workaround_dtypes:
             return need_workaround_dtypes[dtype]
         return dtype
+
+    def get_storage_shape(
+        self, dtype: DType, shape: List[int], strides: List[int]
+    ) -> "tuple[List[int], List[int]]":
+        size = self.get_dtype_size(dtype)
+        if size < 1.0:
+            # Packed sub-byte dtype: collapse to flat byte count so the
+            # workaround-dtype DLPack tensor doesn't overread the buffer.
+            import math
+
+            ratio = int(round(1.0 / size))  # e.g. 2 for F4 (2 FP4 per byte)
+            if not shape or shape[-1] % ratio > 0:
+                raise ValueError(
+                    f"Malformed input: {shape=}, {ratio=}, "
+                    "last dimension must be divisible by the packing ratio."
+                )
+            nbytes = int(math.prod(shape) * size)
+            return [nbytes], [1]
+        return shape, strides
+
+    def get_native_shape(self, dtype: DType, st_shape: List[int]) -> List[int]:
+        size = self.get_dtype_size(dtype)
+        if size < 1.0:
+            # safetensors counts logical sub-byte elements; PyTorch counts
+            # packed storage units (bytes). Compress the last dimension.
+            import math
+
+            ratio = int(round(1.0 / size))  # e.g. 2 for F4 (2 FP4 per byte)
+            if not st_shape or st_shape[-1] % ratio > 0:
+                raise ValueError(
+                    f"Malformed input: {st_shape=}, {ratio=}, "
+                    "last dimension must be divisible by the packing ratio."
+                )
+            if len(st_shape) > 1:
+                return list(st_shape[:-1]) + [st_shape[-1] // ratio]
+            return [int(math.prod(st_shape) * size)]
+        return st_shape
+
+    def get_native_slices(
+        self, dtype: DType, st_shape: List[int], slices: Tuple
+    ) -> Tuple:
+        size = self.get_dtype_size(dtype)
+        if size >= 1.0 or not st_shape or len(slices) < len(st_shape):
+            return slices
+
+        ratio = int(round(1.0 / size))  # e.g. 2 for F4 (2 FP4 per byte)
+        last_dim = len(st_shape) - 1
+        native_slices = list(slices)
+        last = native_slices[last_dim]
+        if isinstance(last, slice):
+            step = 1 if last.step is None else last.step
+            if step != 1:
+                raise ValueError(
+                    f"Malformed input: {slices=}, {ratio=}, "
+                    "packed sub-byte slices only support step=1."
+                )
+            start = 0 if last.start is None else last.start
+            stop = st_shape[last_dim] if last.stop is None else last.stop
+            start = min(max(start, 0), st_shape[last_dim])
+            stop = min(max(stop, 0), st_shape[last_dim])
+            if start % ratio > 0 or stop % ratio > 0:
+                raise ValueError(
+                    f"Malformed input: {slices=}, {ratio=}, "
+                    "packed sub-byte slice bounds must align to storage units."
+                )
+            native_start = start // ratio
+            native_stop = stop // ratio
+            native_slices[last_dim] = slice(native_start, native_stop, step)
+        elif isinstance(last, int):
+            if last % ratio > 0:
+                raise ValueError(
+                    f"Malformed input: {slices=}, {ratio=}, "
+                    "packed sub-byte indices must align to storage units."
+                )
+            native_slices[last_dim] = last // ratio
+        return tuple(native_slices)
 
     def get_process_group(self, pg: Optional[Any]) -> TorchProcessGroup:
         if pg is not None:

--- a/fastsafetensors/st_types.py
+++ b/fastsafetensors/st_types.py
@@ -58,4 +58,6 @@ class DType(Enum):
     BF16 = "BF16"
     F8_E5M2 = "F8_E5M2"
     F8_E4M3 = "F8_E4M3"
+    F8_E8M0 = "F8_E8M0"
+    F4 = "F4"
     AUTO = "AUTO"

--- a/fastsafetensors/tensor_factory.py
+++ b/fastsafetensors/tensor_factory.py
@@ -166,7 +166,12 @@ class LazyTensorFactory:
                     )
                 t = self.tensors[tensor_name]
                 scatter_list = [
-                    t[rank_slices[rank]].contiguous() for rank in range(0, pg.size())
+                    t[
+                        self.framework.get_native_slices(
+                            frame.dtype, frame.shape, rank_slices[rank]
+                        )
+                    ].contiguous()
+                    for rank in range(0, pg.size())
                 ]  # scatter requires contiguous tensor
             logger.debug(
                 "shuffle: scatter, tensor_name=%s, shape=%s->%s, self.rank=%d, pg.rank()=%d, rank_slices=%s, len(scatter_list)=%s",
@@ -195,8 +200,11 @@ class LazyTensorFactory:
             frame = self.metadata.tensors[tensor_name]
             total_size = frame.shape[dim]
             block_size = (total_size + pg.size() - 1) // pg.size()
+            shard_start = pg.rank() * block_size
+            shard_stop = min((pg.rank() + 1) * block_size, total_size)
+            shard_size = max(shard_stop - shard_start, 0)
             if len(new_shape) == 0:
-                new_shape = frame.shape
+                new_shape = list(frame.shape)
                 new_shape[dim] = 0
             else:
                 for dim2 in range(0, len(frame.shape)):
@@ -204,7 +212,7 @@ class LazyTensorFactory:
                         raise Exception(
                             f"dim {dim2} mismatch: tensor {tensor_name} has {frame.shape} vs. {new_shape} (dim={dim})"
                         )
-            new_shape[dim] += block_size
+            new_shape[dim] += shard_size
             if self.rank == pg.rank():
                 if tensor_name not in self.tensors:
                     raise Exception(
@@ -221,7 +229,13 @@ class LazyTensorFactory:
                                 slice(rank * block_size, (rank + 1) * block_size, 1),
                             )
                             break
-                    rank_tensors[rank].append(t[rank_slices])
+                    rank_tensors[rank].append(
+                        t[
+                            self.framework.get_native_slices(
+                                frame.dtype, frame.shape, rank_slices
+                            )
+                        ]
+                    )
         if pg.size() == 1:
             return self.framework.concat_tensors(rank_tensors[self.rank], dim=dim)
         scatter_list: List[TensorBase] = []

--- a/tests/unit/test_fastsafetensors.py
+++ b/tests/unit/test_fastsafetensors.py
@@ -668,6 +668,94 @@ def test_float8_e4m3fn_to_int8(fstcpp_log, tmp_dir, framework) -> None:
     _test_type(tmp_dir, DType.F8_E4M3, device, framework, DType.I8)
 
 
+def test_float4_e2m1fn_x2(fstcpp_log, tmp_dir, framework) -> None:
+    """Test bit-exact round-trip for F4 (torch.float4_e2m1fn_x2).
+
+    F4 is a packed FP4 format (two 4-bit values per byte, dtype string "F4" in
+    safetensors) used for expert weight matrices in models like DeepSeek V4-Flash.
+
+    The safetensors shape is in FP4-element count while torch.float4_e2m1fn_x2
+    counts packed byte-pairs, so the PyTorch shape has half as many elements in
+    the last dimension.  fastsafetensors handles the shape conversion internally.
+    """
+    if framework.get_name() != "pytorch":
+        pytest.skip("F4 is only available in PyTorch")
+        return
+    import torch
+
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        pytest.skip("torch.float4_e2m1fn_x2 requires PyTorch 2.10+")
+        return
+    device, _ = get_and_check_device(framework)
+    filename = os.path.join(tmp_dir, "f4.safetensors")
+    # F4 tensors cannot be created via randn/cast; create via uint8 view.
+    # Shape [8, 16] in FP4-element terms = shape [8, 8] in float4_e2m1fn_x2.
+    u8 = torch.arange(64, dtype=torch.uint8, device=device.as_str()).reshape(8, 8)
+    t0 = u8.view(torch.float4_e2m1fn_x2)
+    save_safetensors_file({"a": t0}, filename, {"fst": "sample"}, framework)
+    t_ref = load_safetensors_file(filename, device, framework)
+    with fastsafe_open(
+        filenames=[filename],
+        nogds=True,
+        device=device.as_str(),
+        framework=framework.get_name(),
+        debug_log=True,
+    ) as f:
+        for key in f.keys():
+            t1 = f.get_tensor_wrapped(key).clone().detach()
+            assert framework.is_equal(t1, t_ref[key])
+    assert framework.get_mem_used() == 0
+    assert fstcpp.get_cpp_metrics().bounce_buffer_bytes == 0
+
+
+def test_float4_native_shape_and_slices(framework) -> None:
+    if framework.get_name() != "pytorch":
+        pytest.skip("F4 is only available in PyTorch")
+        return
+
+    assert framework.get_native_shape(DType.F4, [8, 16]) == [8, 8]
+    assert framework.get_native_shape(DType.F4, [16]) == [8]
+    assert framework.get_storage_shape(DType.F4, [8, 16], [16, 1]) == (
+        [64],
+        [1],
+    )
+    assert framework.get_native_slices(
+        DType.F4, [8, 16], (slice(None, None, None), slice(4, 12, 1))
+    ) == (slice(None, None, None), slice(2, 6, 1))
+    implicit_last_dim = framework.get_native_slices(
+        DType.F4, [8, 16], (slice(2, 6, 1),)
+    )
+    assert implicit_last_dim == (slice(2, 6, 1),)
+
+    with pytest.raises(ValueError):
+        framework.get_native_shape(DType.F4, [8, 15])
+    with pytest.raises(ValueError):
+        framework.get_storage_shape(DType.F4, [8, 15], [15, 1])
+    with pytest.raises(ValueError):
+        framework.get_native_slices(
+            DType.F4, [8, 16], (slice(None, None, None), slice(3, 12, 1))
+        )
+
+
+def test_float8_e8m0fnu(fstcpp_log, tmp_dir, framework) -> None:
+    """Test bit-exact round-trip for F8_E8M0 (torch.float8_e8m0fnu).
+
+    F8_E8M0 is an unsigned 8-bit exponent-only format used as per-tile
+    quantization scales in models like DeepSeek V4-Flash.  It has no mantissa
+    bits, so ordinary randn -> cast is safe for creating test tensors.
+    """
+    if framework.get_name() != "pytorch":
+        pytest.skip("F8_E8M0 is only available in PyTorch")
+        return
+    import torch
+
+    if not hasattr(torch, "float8_e8m0fnu"):
+        pytest.skip("torch.float8_e8m0fnu requires PyTorch 2.5+")
+        return
+    device, _ = get_and_check_device(framework)
+    _test_type(tmp_dir, DType.F8_E8M0, device, framework)
+
+
 def test_cpp_metrics(fstcpp_log, framework) -> None:
     device, _ = get_and_check_device(framework)
     exp_length = 0

--- a/tests/unit/test_multi.py
+++ b/tests/unit/test_multi.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 from fastsafetensors import SafeTensorsFileLoader
 from fastsafetensors import cpp as fstcpp
 from fastsafetensors.common import is_gpu_found
+from fastsafetensors.st_types import DType
 
 
 def test_shuffle(fstcpp_log, input_files, pg, framework):
@@ -109,6 +112,81 @@ def test_shuffle(fstcpp_log, input_files, pg, framework):
             [origs["h.0.mlp.c_proj.weight"], origs["h.1.mlp.c_proj.weight"]], axis=1
         )
         assert framework.is_equal(actual, exp)
+
+    bufs.close()
+    loader.close()
+    assert framework.get_mem_used() == 0
+    assert fstcpp.get_cpp_metrics().bounce_buffer_bytes == 0
+
+
+def test_float4_shuffle_last_dim(fstcpp_log, tmp_dir, pg, framework):
+    if framework.get_name() != "pytorch":
+        pytest.skip("F4 is only available in PyTorch")
+        return
+
+    import torch
+    import torch.distributed as dist
+    from safetensors.torch import load_file, save_file
+
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        pytest.skip("torch.float4_e2m1fn_x2 requires PyTorch 2.10+")
+        return
+
+    rank = pg.rank()
+    world_size = pg.size()
+    device = f"cuda:{rank}" if is_gpu_found() else "cpu"
+    filename = os.path.join(tmp_dir, "multi_f4.safetensors")
+
+    if rank == 0:
+        # Native PyTorch shape [8, 16] is safetensors logical shape [8, 32].
+        a_u8 = torch.arange(128, dtype=torch.uint8).reshape(8, 16)
+        b_u8 = (torch.arange(128, dtype=torch.uint8) + 128).reshape(8, 16)
+        save_file(
+            {
+                "f4_a": a_u8.view(torch.float4_e2m1fn_x2),
+                "f4_b": b_u8.view(torch.float4_e2m1fn_x2),
+            },
+            filename,
+            {"fst": "sample"},
+        )
+    if world_size > 1:
+        dist.barrier(group=pg)
+
+    loader = SafeTensorsFileLoader(
+        pg=pg, device=device, nogds=True, framework=framework.get_name(), debug_log=True
+    )
+    loader.add_filenames({0: [filename]})
+    bufs = loader.copy_files_to_device()
+    logical_shape = loader.get_shape("f4_a")
+    assert logical_shape == [8, 32]
+
+    tensors = bufs.as_dict({"f4_a": 1, "f4_b": 1})
+    refs = load_file(filename, device=device)
+    block_size = (logical_shape[1] + world_size - 1) // world_size
+    rank_slice = (
+        slice(None, None, None),
+        slice(rank * block_size, (rank + 1) * block_size, 1),
+    )
+    native_slice = framework.get_native_slices(DType.F4, logical_shape, rank_slice)
+
+    assert framework.is_equal(tensors["f4_a"], refs["f4_a"][native_slice])
+    assert framework.is_equal(tensors["f4_b"], refs["f4_b"][native_slice])
+
+    bufs.close()
+    loader.reset()
+
+    loader.add_filenames({0: [filename]})
+    bufs = loader.copy_files_to_device()
+    actual = bufs.get_multi_cols(["f4_a", "f4_b"], dim=1)
+    expected_u8 = torch.cat(
+        [
+            refs["f4_a"][native_slice].view(torch.uint8),
+            refs["f4_b"][native_slice].view(torch.uint8),
+        ],
+        dim=1,
+    )
+    expected = expected_u8.view(torch.float4_e2m1fn_x2)
+    assert framework.is_equal(actual, expected)
 
     bufs.close()
     loader.close()

--- a/tests/unit/test_multi.py
+++ b/tests/unit/test_multi.py
@@ -194,6 +194,101 @@ def test_float4_shuffle_last_dim(fstcpp_log, tmp_dir, pg, framework):
     assert fstcpp.get_cpp_metrics().bounce_buffer_bytes == 0
 
 
+def test_float4_float8_e8m0_collectives(fstcpp_log, tmp_dir, pg, framework):
+    if framework.get_name() != "pytorch":
+        pytest.skip("F4 and F8_E8M0 are only available in PyTorch")
+        return
+
+    import torch
+    import torch.distributed as dist
+    from safetensors.torch import load_file, save_file
+
+    if not hasattr(torch, "float4_e2m1fn_x2"):
+        pytest.skip("torch.float4_e2m1fn_x2 requires PyTorch 2.10+")
+        return
+    if not hasattr(torch, "float8_e8m0fnu"):
+        pytest.skip("torch.float8_e8m0fnu requires PyTorch 2.5+")
+        return
+
+    rank = pg.rank()
+    world_size = pg.size()
+    device = f"cuda:{rank}" if is_gpu_found() else "cpu"
+    filename = os.path.join(tmp_dir, "multi_collectives_f4_f8e8m0.safetensors")
+
+    if rank == 0:
+        f4_u8 = torch.arange(128, dtype=torch.uint8).reshape(8, 16)
+        f8_u8 = torch.arange(128, 192, dtype=torch.uint8).reshape(8, 8)
+        save_file(
+            {
+                "f4": f4_u8.view(torch.float4_e2m1fn_x2),
+                "f8_e8m0": f8_u8.view(torch.float8_e8m0fnu),
+            },
+            filename,
+            {"fst": "sample"},
+        )
+    if world_size > 1:
+        dist.barrier(group=pg)
+
+    refs = load_file(filename, device=device)
+
+    loader = SafeTensorsFileLoader(
+        pg=pg, device=device, nogds=True, framework=framework.get_name(), debug_log=True
+    )
+    loader.add_filenames({0: [filename]})
+    bufs = loader.copy_files_to_device()
+    assert framework.is_equal(bufs.get_tensor_wrapped("f4"), refs["f4"])
+    assert framework.is_equal(bufs.get_tensor_wrapped("f8_e8m0"), refs["f8_e8m0"])
+    bufs.close()
+    loader.reset()
+
+    loader.add_filenames({0: [filename]})
+    bufs = loader.copy_files_to_device()
+    tensors = bufs.as_dict({"f4": 1, "f8_e8m0": 1})
+    f4_logical_shape = loader.get_shape("f4")
+    f4_block_size = (f4_logical_shape[1] + world_size - 1) // world_size
+    f4_logical_slice = (
+        slice(None, None, None),
+        slice(rank * f4_block_size, (rank + 1) * f4_block_size, 1),
+    )
+    f4_native_slice = framework.get_native_slices(
+        DType.F4, f4_logical_shape, f4_logical_slice
+    )
+    f8_block_size = (refs["f8_e8m0"].shape[1] + world_size - 1) // world_size
+    f8_slice = (
+        slice(None, None, None),
+        slice(rank * f8_block_size, (rank + 1) * f8_block_size, 1),
+    )
+    assert framework.is_equal(tensors["f4"], refs["f4"][f4_native_slice])
+    assert framework.is_equal(tensors["f8_e8m0"], refs["f8_e8m0"][f8_slice])
+    bufs.close()
+    loader.reset()
+
+    loader.add_filenames({0: [filename]})
+    bufs = loader.copy_files_to_device()
+    if world_size > 1:
+        pushed_f4 = bufs.push_tensor("f4", 1)
+        pushed_f8 = bufs.push_tensor("f8_e8m0", 1)
+        if rank == 1:
+            assert pushed_f4 is not None
+            assert pushed_f8 is not None
+            assert bool(
+                torch.equal(pushed_f4.view(torch.uint8), refs["f4"].view(torch.uint8))
+            )
+            assert bool(
+                torch.equal(
+                    pushed_f8.view(torch.uint8), refs["f8_e8m0"].view(torch.uint8)
+                )
+            )
+        else:
+            assert pushed_f4 is None
+            assert pushed_f8 is None
+    bufs.close()
+    loader.close()
+
+    assert framework.get_mem_used() == 0
+    assert fstcpp.get_cpp_metrics().bounce_buffer_bytes == 0
+
+
 if __name__ == "__main__":
     import os
     import sys


### PR DESCRIPTION
Add support for safetensors F4 and F8_E8M0 tensors used by recent mixed-precision models.

F8_E8M0 maps to torch.float8_e8m0fnu when available. F4 maps to torch.float4_e2m1fn_x2 when available; since PyTorch represents this dtype as packed pairs, convert safetensors logical FP4 shapes to PyTorch-native packed shapes when loading and allocating tensors.

Use uint8 views for F4 and F8_E8M0 collective operations. NCCL does not provide native support for these dtypes, and the operation must preserve the stored bits rather than perform a value conversion. Apply this path to broadcast, scatter, send, recv, and tensor concatenation used by shuffling.

Validate malformed packed FP4 shapes instead of silently truncating odd logical dimensions. Also translate logical safetensors slices to native packed slices for sharded loads, including scatter and multi-column shuffle.

This change is based on the original PR by Umar <uasind@gmail.com>, with additional fixes for dtype collectives, packed-shape validation, and sharded F4 slicing.

Reported-by: Git Bisector <gitbisector@gmail.com>

CC: @gitbisector 