### PR TITLE
Add Windows ARM64 wheel builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,23 +18,19 @@ jobs:
             runner: ubuntu-latest
             build: manylinux_x86_64
             cibw_arch: x86_64
-            setup_arch: x64
           - arch: aarch64
             runner: ubuntu-24.04-arm
             build: manylinux_aarch64
             cibw_arch: aarch64
-            setup_arch: arm64
           - arch: win_amd64
             runner: windows-latest
             build: win_amd64
             cibw_arch: AMD64
-            setup_arch: x64
             redist_arch: x64
           - arch: win_arm64
             runner: windows-11-arm
             build: win_arm64
             cibw_arch: ARM64
-            setup_arch: arm64
             redist_arch: arm64
 
     steps:
@@ -45,7 +41,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
-        architecture: ${{ matrix.platform.setup_arch }}
 
     # The wheel is built with the image's newest MSVC toolset, but the
     # image's installed VC redistributable can lag behind it (14.40 vs 14.51

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,14 +18,24 @@ jobs:
             runner: ubuntu-latest
             build: manylinux_x86_64
             cibw_arch: x86_64
+            setup_arch: x64
           - arch: aarch64
             runner: ubuntu-24.04-arm
             build: manylinux_aarch64
             cibw_arch: aarch64
+            setup_arch: arm64
           - arch: win_amd64
             runner: windows-latest
             build: win_amd64
             cibw_arch: AMD64
+            setup_arch: x64
+            redist_arch: x64
+          - arch: win_arm64
+            runner: windows-11-arm
+            build: win_arm64
+            cibw_arch: ARM64
+            setup_arch: arm64
+            redist_arch: arm64
 
     steps:
     - name: Checkout code
@@ -35,6 +45,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
+        architecture: ${{ matrix.platform.setup_arch }}
 
     # The wheel is built with the image's newest MSVC toolset, but the
     # image's installed VC redistributable can lag behind it (14.40 vs 14.51
@@ -48,13 +59,15 @@ jobs:
         $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
         $vs = & $vswhere -latest -products * -property installationPath
         if (-not $vs) { throw "Visual Studio installation not found" }
-        $redist = Get-ChildItem "$vs\VC\Redist\MSVC" -Recurse -Filter vc_redist.x64.exe |
+        $redistArch = "${{ matrix.platform.redist_arch }}"
+        $redistName = "vc_redist.$redistArch.exe"
+        $redist = Get-ChildItem "$vs\VC\Redist\MSVC" -Recurse -Filter $redistName |
           Sort-Object { $_.VersionInfo.FileVersionRaw } | Select-Object -Last 1
-        if (-not $redist) { throw "vc_redist.x64.exe not found under $vs" }
+        if (-not $redist) { throw "$redistName not found under $vs" }
         Write-Host "Installing $($redist.FullName) ($($redist.VersionInfo.FileVersion))"
         $p = Start-Process -FilePath $redist.FullName -ArgumentList '/install','/quiet','/norestart' -Wait -PassThru
         # 1638: same or newer version already installed; 3010: success, reboot required
-        if ($p.ExitCode -notin 0, 1638, 3010) { throw "vc_redist.x64.exe exited with $($p.ExitCode)" }
+        if ($p.ExitCode -notin 0, 1638, 3010) { throw "$redistName exited with $($p.ExitCode)" }
 
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel setuptools pybind11
@@ -66,9 +79,9 @@ jobs:
         CIBW_SKIP: "*-musllinux_* *-win32 *-manylinux_i686"
         CIBW_TEST_COMMAND: "python {project}/tests/smoke_import_cpp.py"
         CIBW_ARCHS: "${{ matrix.platform.cibw_arch }}"
-        # Bundle MSVC runtime satellite DLLs into the wheel; the VS2026 runner
-        # image builds against a toolchain newer than what end-user machines
-        # (and the test env) may have installed.
+        # Bundle MSVC runtime satellite DLLs into the wheel; Windows runner
+        # images can build against a toolchain newer than what end-user
+        # machines (and the test env) may have installed.
         CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
         # --add-path makes delvewheel take msvcp140.dll from System32 (kept
         # current by the redist step above) instead of a stale copy that some


### PR DESCRIPTION
Hi @takeshi-yoshimura, I'm from Microsoft and recently I've been working on improving Python ecosystem support for Windows on Arm. This PR adds CI support for Windows ARM64. Thanks for reviewing it.

## Summary

- add native `windows-11-arm` runners to the release wheel matrix
- build `win_arm64` wheels for CPython 3.10 through 3.14 with cibuildwheel
- let `setup-python` use each runner's native architecture
- install the architecture-matched VC++ redistributable before repairing Windows wheels with delvewheel

## Validation

- parsed the updated workflow and verified the Windows ARM64 matrix entry
- confirmed cibuildwheel selects `cp310-win_arm64` through `cp314-win_arm64`
- built and repaired `fastsafetensors-0.3.3-cp313-cp313-win_arm64.whl` on native Windows ARM64 with cibuildwheel 4.1.1
- installed the repaired wheel in cibuildwheel's isolated test environment and passed `dump_pyd_imports.py` and `smoke_import_cpp.py`
- pipeline run successfully: https://github.com/chinazhangchao/fastsafetensors/actions/runs/30990883576