### PR TITLE
Improve DirectStorage fallback and CUDA runtime discovery

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -69,3 +69,8 @@ The key steps are:
 5. Synchronize using a D3D12 fence imported as a cudaExternalSemaphore
 
 All DirectStorage, D3D12, and DXGI libraries are loaded at runtime via LoadLibrary/GetProcAddress — no link-time SDK dependency on DirectStorage is required.
+
+If the DirectStorage DLLs are not installed, the Windows loader falls back to
+the bounce-buffer (`nogds`) path. Set `FASTSAFETENSORS_DSTORAGE_DLL_DIR` to an
+absolute directory containing `dstoragecore.dll` and `dstorage.dll` to enable
+DirectStorage; an invalid explicit directory remains an error.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -74,3 +74,8 @@ If the DirectStorage DLLs are not installed, the Windows loader falls back to
 the bounce-buffer (`nogds`) path. Set `FASTSAFETENSORS_DSTORAGE_DLL_DIR` to an
 absolute directory containing `dstoragecore.dll` and `dstorage.dll` to enable
 DirectStorage; an invalid explicit directory remains an error.
+
+The fallback resolves a framework-bundled CUDA runtime first (for example,
+PyTorch's `torch\lib` directory), then checks system CUDA Toolkit locations.
+`FASTSAFETENSORS_CUDART_LIB` can specify an absolute runtime DLL explicitly and
+takes precedence over automatic discovery.

--- a/fastsafetensors/common.py
+++ b/fastsafetensors/common.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import sys
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -139,10 +140,14 @@ def _resolve_windows_cudart_lib_name(framework=None) -> str:
         d = os.path.abspath(expanded)
         if not os.path.isdir(d):
             return ""
-        matches = glob.glob(os.path.join(d, "cudart64*.dll"))
+        matches = []
+        for path in glob.glob(os.path.join(d, "cudart64_*.dll")):
+            match = re.fullmatch(r"cudart64_(\d+)\.dll", os.path.basename(path))
+            if match:
+                matches.append((int(match.group(1)), path))
         if matches:
-            matches.sort(reverse=True)
-            return os.path.abspath(matches[0])
+            matches.sort(key=lambda item: item[0], reverse=True)
+            return os.path.abspath(matches[0][1])
         return ""
 
     def _detect_from_nvcc(cuda_home: str) -> str:
@@ -199,7 +204,15 @@ def _resolve_windows_cudart_lib_name(framework=None) -> str:
     if os.path.isdir(nvidia_base):
         # List version directories (e.g. v12.6, v11.8), newest first
         try:
-            versions = sorted(os.listdir(nvidia_base), reverse=True)
+            versions = sorted(
+                (
+                    version
+                    for version in os.listdir(nvidia_base)
+                    if re.fullmatch(r"v\d+(?:\.\d+)*", version)
+                ),
+                key=lambda version: tuple(int(part) for part in version[1:].split(".")),
+                reverse=True,
+            )
         except OSError:
             versions = []
         for ver_dir in versions:

--- a/fastsafetensors/common.py
+++ b/fastsafetensors/common.py
@@ -103,7 +103,7 @@ def resolve_runtime_lib_name(framework=None) -> str:
     back to auto-detection.
     """
     if sys.platform == "win32":
-        return _resolve_windows_cudart_lib_name()
+        return _resolve_windows_cudart_lib_name(framework)
     if framework is None:
         return ""
     try:
@@ -120,7 +120,7 @@ def resolve_runtime_lib_name(framework=None) -> str:
     return ""
 
 
-def _resolve_windows_cudart_lib_name() -> str:
+def _resolve_windows_cudart_lib_name(framework=None) -> str:
     """Resolve the absolute cudart DLL path on Windows, "" for the default."""
     # Allow explicit override via environment variable
     override = os.environ.get("FASTSAFETENSORS_CUDART_LIB", "").strip()
@@ -139,7 +139,7 @@ def _resolve_windows_cudart_lib_name() -> str:
         d = os.path.abspath(expanded)
         if not os.path.isdir(d):
             return ""
-        matches = glob.glob(os.path.join(d, "cudart64_*.dll"))
+        matches = glob.glob(os.path.join(d, "cudart64*.dll"))
         if matches:
             matches.sort(reverse=True)
             return os.path.abspath(matches[0])
@@ -170,6 +170,18 @@ def _resolve_windows_cudart_lib_name() -> str:
             return ""
         except Exception:
             return ""
+
+    # Framework wheels such as PyTorch can bundle cudart without installing a
+    # system CUDA Toolkit.
+    if framework is not None:
+        try:
+            runtime_dirs = framework.get_runtime_lib_dirs()
+        except (AttributeError, OSError):
+            runtime_dirs = []
+        for runtime_dir in runtime_dirs:
+            result = _find_cudart_in_dir(runtime_dir)
+            if result:
+                return result
 
     # Try to detect from CUDA_HOME / CUDA_PATH
     cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")

--- a/fastsafetensors/copier/dstorage.py
+++ b/fastsafetensors/copier/dstorage.py
@@ -111,17 +111,17 @@ def load_dstorage_dlls() -> None:
     _dstorage_dll_dir = dll_dir
 
 
-def init_dstorage(device_id: int = 0) -> None:
+def init_dstorage(device_id: int = 0, framework: FrameworkOpBase | None = None) -> None:
     global _inited_ds
     if not _inited_ds:
         from .nogds import load_library_func
 
         load_dstorage_dlls()
-        load_library_func()
+        load_library_func(framework)
         if not is_gpu_found():
             raise RuntimeError("CUDA runtime not found")
         # Windows-only; resolve_runtime_lib_name() returns the cudart DLL path here
-        cudart_dll = resolve_runtime_lib_name()
+        cudart_dll = resolve_runtime_lib_name(framework)
         if not cudart_dll:
             raise RuntimeError("Could not find CUDA runtime DLL")
         if _dstorage_dll_dir is None:
@@ -187,7 +187,10 @@ class DStorageFileCopier(CopierInterface):
 def new_dstorage_copier(device: Device, **kwargs) -> CopierConstructFunc:
     """Factory for DirectStorage file copier."""
     try:
-        init_dstorage(device.index if device.index is not None else 0)
+        init_dstorage(
+            device.index if device.index is not None else 0,
+            kwargs.get("framework"),
+        )
     except DirectStorageUnavailableError as e:
         global _warned_dstorage_fallback
         if not _warned_dstorage_fallback:

--- a/fastsafetensors/copier/dstorage.py
+++ b/fastsafetensors/copier/dstorage.py
@@ -16,16 +16,22 @@ from ..common import (
 from ..frameworks import FrameworkOpBase, TensorBase
 from ..st_types import Device, DeviceType, DType
 from .base import CopierInterface
+from .nogds import new_nogds_file_copier
 from .registry import CopierConstructFunc, register_copier_constructor
 
 logger = init_logger(__name__)
 
 _inited_ds = False
+_warned_dstorage_fallback = False
 _dstorage_dll_dir_handle = None
 _dstorage_dll_dir: Path | None = None
 _DSTORAGE_DLLS = ("dstoragecore.dll", "dstorage.dll")
 _DSTORAGE_DLL_DIR_ENV_VAR = "FASTSAFETENSORS_DSTORAGE_DLL_DIR"
 _LEGACY_DSTORAGE_DOWNLOAD_ENV_VAR = "FASTSAFETENSORS_DSTORAGE_NUPKG_URL"
+
+
+class DirectStorageUnavailableError(RuntimeError):
+    """DirectStorage is not installed in an auto-discovered location."""
 
 
 def _get_dstorage_cache_dir() -> Path:
@@ -71,7 +77,7 @@ def resolve_dstorage_dll_dir() -> Path:
         except FileNotFoundError:
             pass
 
-    raise RuntimeError(
+    raise DirectStorageUnavailableError(
         "DirectStorage DLLs were not found. Install dstoragecore.dll and "
         "dstorage.dll into an absolute directory and set "
         f"{_DSTORAGE_DLL_DIR_ENV_VAR}, or place them in {cache_dir}."
@@ -180,7 +186,18 @@ class DStorageFileCopier(CopierInterface):
 @register_copier_constructor("dstorage")
 def new_dstorage_copier(device: Device, **kwargs) -> CopierConstructFunc:
     """Factory for DirectStorage file copier."""
-    init_dstorage(device.index if device.index is not None else 0)
+    try:
+        init_dstorage(device.index if device.index is not None else 0)
+    except DirectStorageUnavailableError as e:
+        global _warned_dstorage_fallback
+        if not _warned_dstorage_fallback:
+            _warned_dstorage_fallback = True
+            logger.warning(
+                "DirectStorage is unavailable (%s); falling back to the nogds copier",
+                str(e),
+            )
+        return new_nogds_file_copier(device, **kwargs)
+
     stream_reader = fstcpp.dstorage_stream_reader()
     if not stream_reader.is_ready():
         raise RuntimeError("dstorage_stream_reader failed to initialize")

--- a/fastsafetensors/frameworks/__init__.py
+++ b/fastsafetensors/frameworks/__init__.py
@@ -160,6 +160,10 @@ class FrameworkOpBase(ABC, Generic[T, K]):
     def get_cuda_ver(self) -> str:
         pass
 
+    def get_runtime_lib_dirs(self) -> List[str]:
+        """Return trusted directories containing framework-bundled GPU runtimes."""
+        return []
+
     @abstractmethod
     def get_device_ptr_align(self) -> int:
         pass

--- a/fastsafetensors/frameworks/_torch.py
+++ b/fastsafetensors/frameworks/_torch.py
@@ -6,6 +6,7 @@ try:
 except ImportError as e:
     raise ImportError("could not import torch. Please install it.") from e
 
+import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -302,6 +303,13 @@ class TorchOp(FrameworkOpBase[TorchTensor, TorchProcessGroup]):
                 return f"hip-{torch.version.hip}"
             return f"cuda-{torch.version.cuda}"
         return "0.0"
+
+    def get_runtime_lib_dirs(self) -> List[str]:
+        torch_c_file = getattr(getattr(torch, "_C", None), "__file__", None)
+        torch_file = torch_c_file or getattr(torch, "__file__", None)
+        if not torch_file:
+            return []
+        return [os.path.join(os.path.dirname(os.path.abspath(torch_file)), "lib")]
 
     def get_device_ptr_align(self) -> int:
         CUDA_PTR_ALIGN: int = 16

--- a/tests/unit/test_robustness.py
+++ b/tests/unit/test_robustness.py
@@ -43,6 +43,68 @@ def test_get_fs_type_unreadable_mounts(tmp_path):
     assert get_fs_type("/data/x", str(tmp_path / "nope")) == ""
 
 
+# ---- DirectStorage -> nogds fallback ----
+
+
+def test_missing_dstorage_dlls_fall_back_to_nogds(monkeypatch, caplog, tmp_path):
+    import logging
+
+    from fastsafetensors.copier import dstorage
+    from fastsafetensors.st_types import Device
+
+    fallback_constructor = object()
+    fallback_calls = []
+
+    def make_fallback(device, **kwargs):
+        fallback_calls.append((device, kwargs))
+        return fallback_constructor
+
+    monkeypatch.setattr(dstorage.sys, "platform", "win32")
+    monkeypatch.delenv(dstorage._DSTORAGE_DLL_DIR_ENV_VAR, raising=False)
+    monkeypatch.delenv(dstorage._LEGACY_DSTORAGE_DOWNLOAD_ENV_VAR, raising=False)
+    monkeypatch.setattr(
+        dstorage, "_get_dstorage_cache_dir", lambda: tmp_path / "missing"
+    )
+    monkeypatch.setattr(dstorage, "_inited_ds", False)
+    monkeypatch.setattr(dstorage, "new_nogds_file_copier", make_fallback)
+    monkeypatch.setattr(dstorage, "_warned_dstorage_fallback", False)
+    device = Device.from_str("cuda:0")
+
+    with caplog.at_level(logging.WARNING, logger="fastsafetensors.copier.dstorage"):
+        result = dstorage.new_dstorage_copier(
+            device, framework="pytorch", bbuf_size_kb=4096, max_threads=4
+        )
+        dstorage.new_dstorage_copier(device, framework="pytorch")
+
+    assert result is fallback_constructor
+    assert fallback_calls[0] == (
+        device,
+        {"framework": "pytorch", "bbuf_size_kb": 4096, "max_threads": 4},
+    )
+    assert caplog.text.count("falling back to the nogds copier") == 1
+
+
+def test_explicit_dstorage_configuration_error_does_not_fall_back(
+    monkeypatch, tmp_path
+):
+    from fastsafetensors.copier import dstorage
+    from fastsafetensors.st_types import Device
+
+    configured_dir = tmp_path / "missing"
+    monkeypatch.setattr(dstorage.sys, "platform", "win32")
+    monkeypatch.setenv(dstorage._DSTORAGE_DLL_DIR_ENV_VAR, str(configured_dir))
+    monkeypatch.delenv(dstorage._LEGACY_DSTORAGE_DOWNLOAD_ENV_VAR, raising=False)
+    monkeypatch.setattr(dstorage, "_inited_ds", False)
+    monkeypatch.setattr(
+        dstorage,
+        "new_nogds_file_copier",
+        lambda *args, **kwargs: pytest.fail("unexpected nogds fallback"),
+    )
+
+    with pytest.raises(FileNotFoundError, match="FASTSAFETENSORS_DSTORAGE_DLL_DIR"):
+        dstorage.new_dstorage_copier(Device.from_str("cuda:0"), framework="pytorch")
+
+
 # ---- O_DIRECT gating on network filesystems ----
 
 

--- a/tests/unit/test_runtime_hint.py
+++ b/tests/unit/test_runtime_hint.py
@@ -137,6 +137,70 @@ def test_windows_explicit_cudart_takes_precedence(monkeypatch):
         assert result == str(override.absolute())
 
 
+def test_dstorage_initialization_uses_framework_bundled_cudart(monkeypatch):
+    import ctypes
+
+    from fastsafetensors.copier import dstorage, nogds
+    from fastsafetensors.st_types import Device
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        runtime_dir = tmp_path / "torch" / "lib"
+        runtime_dir.mkdir(parents=True)
+        cudart = runtime_dir / "cudart64_12.dll"
+        cudart.touch()
+
+        dstorage_dir = tmp_path / "dstorage"
+        dstorage_dir.mkdir()
+        for dll_name in dstorage._DSTORAGE_DLLS:
+            (dstorage_dir / dll_name).touch()
+
+        framework = _FakeFramework("cuda-12.8", [str(runtime_dir)])
+        loaded_runtimes = []
+        init_calls = []
+
+        class _ReadyStreamReader:
+            def is_ready(self):
+                return True
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delenv("FASTSAFETENSORS_CUDART_LIB", raising=False)
+        monkeypatch.delenv("CUDA_HOME", raising=False)
+        monkeypatch.delenv("CUDA_PATH", raising=False)
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "no-system-cuda"))
+        monkeypatch.setenv(dstorage._DSTORAGE_DLL_DIR_ENV_VAR, str(dstorage_dir))
+        monkeypatch.setattr(ctypes, "WinDLL", lambda path: None, raising=False)
+        monkeypatch.setattr(
+            dstorage.os, "add_dll_directory", lambda path: object(), raising=False
+        )
+        monkeypatch.setattr(
+            nogds.fstcpp, "load_library_functions", loaded_runtimes.append
+        )
+        monkeypatch.setattr(nogds, "is_gpu_found", lambda: True)
+        monkeypatch.setattr(nogds, "_loaded_library", False)
+        monkeypatch.setattr(dstorage, "is_gpu_found", lambda: True)
+        monkeypatch.setattr(dstorage, "_inited_ds", False)
+        monkeypatch.setattr(dstorage, "_dstorage_dll_dir", None)
+        monkeypatch.setattr(dstorage, "_dstorage_dll_dir_handle", None)
+        monkeypatch.setattr(
+            dstorage.fstcpp,
+            "init_dstorage",
+            lambda *args: init_calls.append(args) or "ok",
+        )
+        monkeypatch.setattr(
+            dstorage.fstcpp, "dstorage_stream_reader", _ReadyStreamReader
+        )
+
+        constructor = dstorage.new_dstorage_copier(
+            Device.from_str("cuda:0"), framework=framework
+        )
+
+        expected_cudart = str(cudart.absolute())
+        assert callable(constructor)
+        assert loaded_runtimes == [expected_cudart]
+        assert init_calls == [(0, 0, expected_cudart, str(dstorage_dir))]
+
+
 def test_load_library_func_hint_with_no_gpu_raises(monkeypatch):
     """A hint that finds no GPU is a hard failure"""
     from fastsafetensors.copier import nogds

--- a/tests/unit/test_runtime_hint.py
+++ b/tests/unit/test_runtime_hint.py
@@ -79,6 +79,46 @@ def test_windows_uses_framework_bundled_cudart(monkeypatch):
         assert result == str(cudart.absolute())
 
 
+def test_windows_uses_highest_bundled_cudart_major(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("FASTSAFETENSORS_CUDART_LIB", raising=False)
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    with tempfile.TemporaryDirectory() as tmp:
+        runtime_dir = Path(tmp) / "torch" / "lib"
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / "cudart64_9.dll").touch()
+        cudart = runtime_dir / "cudart64_12.dll"
+        cudart.touch()
+
+        result = common.resolve_runtime_lib_name(
+            _FakeFramework("cuda-12.8", [str(runtime_dir)])
+        )
+
+        assert result == str(cudart.absolute())
+
+
+def test_windows_uses_highest_installed_cuda_version(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("FASTSAFETENSORS_CUDART_LIB", raising=False)
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    with tempfile.TemporaryDirectory() as tmp:
+        cuda_base = Path(tmp) / "NVIDIA GPU Computing Toolkit" / "CUDA"
+        old_bin = cuda_base / "v9.0" / "bin"
+        old_bin.mkdir(parents=True)
+        (old_bin / "cudart64_9.dll").touch()
+        new_bin = cuda_base / "v12.6" / "bin"
+        new_bin.mkdir(parents=True)
+        cudart = new_bin / "cudart64_12.dll"
+        cudart.touch()
+        monkeypatch.setenv("ProgramFiles", tmp)
+
+        result = common.resolve_runtime_lib_name()
+
+        assert result == str(cudart.absolute())
+
+
 def test_windows_explicit_cudart_takes_precedence(monkeypatch):
     monkeypatch.setattr(sys, "platform", "win32")
     with tempfile.TemporaryDirectory() as tmp:

--- a/tests/unit/test_runtime_hint.py
+++ b/tests/unit/test_runtime_hint.py
@@ -3,6 +3,8 @@
 """Unit tests for the framework-hinted GPU runtime selection."""
 
 import sys
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -10,13 +12,17 @@ from fastsafetensors import common
 
 
 class _FakeFramework:
-    def __init__(self, cuda_ver):
+    def __init__(self, cuda_ver, runtime_lib_dirs=None):
         self._ver = cuda_ver
+        self._runtime_lib_dirs = runtime_lib_dirs or []
 
     def get_cuda_ver(self):
         if isinstance(self._ver, Exception):
             raise self._ver
         return self._ver
+
+    def get_runtime_lib_dirs(self):
+        return self._runtime_lib_dirs
 
 
 @pytest.fixture(autouse=True)
@@ -53,6 +59,42 @@ def test_get_cuda_ver_raises_uses_autodetect():
 def test_windows_is_noop(monkeypatch):
     monkeypatch.setattr(sys, "platform", "win32")
     assert common.resolve_runtime_lib_name(_FakeFramework("hip-7.2.0")) == ""
+
+
+def test_windows_uses_framework_bundled_cudart(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("FASTSAFETENSORS_CUDART_LIB", raising=False)
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    with tempfile.TemporaryDirectory() as tmp:
+        runtime_dir = Path(tmp) / "torch" / "lib"
+        runtime_dir.mkdir(parents=True)
+        cudart = runtime_dir / "cudart64_12.dll"
+        cudart.touch()
+
+        result = common.resolve_runtime_lib_name(
+            _FakeFramework("cuda-12.8", [str(runtime_dir)])
+        )
+
+        assert result == str(cudart.absolute())
+
+
+def test_windows_explicit_cudart_takes_precedence(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    with tempfile.TemporaryDirectory() as tmp:
+        override = Path(tmp) / "configured" / "cudart64_12.dll"
+        override.parent.mkdir()
+        override.touch()
+        bundled_dir = Path(tmp) / "torch" / "lib"
+        bundled_dir.mkdir(parents=True)
+        (bundled_dir / "cudart64_13.dll").touch()
+        monkeypatch.setenv("FASTSAFETENSORS_CUDART_LIB", str(override))
+
+        result = common.resolve_runtime_lib_name(
+            _FakeFramework("cuda-12.8", [str(bundled_dir)])
+        )
+
+        assert result == str(override.absolute())
 
 
 def test_load_library_func_hint_with_no_gpu_raises(monkeypatch):


### PR DESCRIPTION
This pull request improves the handling of DirectStorage and CUDA runtime library discovery, especially for Windows environments and framework-bundled runtimes (such as PyTorch). It adds robust fallback mechanisms, better error handling, and framework-aware runtime selection. The changes also introduce new tests covering these scenarios.

**DirectStorage fallback and error handling:**
- The DirectStorage copier (`dstorage`) now falls back to the `nogds` copier if the required DLLs are not installed and emits a warning only once. However, if an explicit DLL directory is set but invalid, it raises an error instead of falling back. [[1]](diffhunk://#diff-10464df479c87362c0ecd194766c6bc3faa3d0d0e456103c76a31e551b48c05bR19-R36) [[2]](diffhunk://#diff-10464df479c87362c0ecd194766c6bc3faa3d0d0e456103c76a31e551b48c05bL74-R80) [[3]](diffhunk://#diff-10464df479c87362c0ecd194766c6bc3faa3d0d0e456103c76a31e551b48c05bR189-R200)
- Introduced the custom exception `DirectStorageUnavailableError` to distinguish between missing DLLs and explicit misconfiguration. [[1]](diffhunk://#diff-10464df479c87362c0ecd194766c6bc3faa3d0d0e456103c76a31e551b48c05bR19-R36) [[2]](diffhunk://#diff-10464df479c87362c0ecd194766c6bc3faa3d0d0e456103c76a31e551b48c05bL74-R80)

**CUDA runtime library discovery improvements:**
- The CUDA runtime discovery on Windows now checks framework-provided runtime directories (e.g., PyTorch's `torch\lib`) before falling back to system locations, and an explicit environment variable always takes precedence. [[1]](diffhunk://#diff-1ffc003d0fe72f60c308ef5fb32020d57905071b28d1d9ccd1020e1066c2a521L106-R106) [[2]](diffhunk://#diff-1ffc003d0fe72f60c308ef5fb32020d57905071b28d1d9ccd1020e1066c2a521L123-R123) [[3]](diffhunk://#diff-1ffc003d0fe72f60c308ef5fb32020d57905071b28d1d9ccd1020e1066c2a521L142-R142) [[4]](diffhunk://#diff-1ffc003d0fe72f60c308ef5fb32020d57905071b28d1d9ccd1020e1066c2a521R174-R185)
- Frameworks can now provide a `get_runtime_lib_dirs` method to supply trusted directories for bundled GPU runtimes. This is implemented for PyTorch. [[1]](diffhunk://#diff-4995bdc3a0c9d085742d86324c29861b27e121aee9fd0b968b68d410a7624416R163-R166) [[2]](diffhunk://#diff-f59f48564cba524577bf40d61e4c98cadb07ff7181dc77b5b1888651aa2e373dR307-R313) [[3]](diffhunk://#diff-f59f48564cba524577bf40d61e4c98cadb07ff7181dc77b5b1888651aa2e373dR9)

**Documentation updates:**
- The overview documentation now clearly describes the DirectStorage fallback behavior and the environment variables for configuration.

**Expanded test coverage:**
- Added tests to verify that the DirectStorage fallback and error handling work as intended, and that CUDA runtime discovery prefers framework-bundled DLLs or explicit overrides. [[1]](diffhunk://#diff-1fce13e49017c6ff601697be919beb9f889667d3a5f6ae82c723f2550ba2f089R46-R107) [[2]](diffhunk://#diff-f1fec3a83947046ce4b6eb75d023a26b5c61d5efd2c5c25b877548566636dc06R6-R26) [[3]](diffhunk://#diff-f1fec3a83947046ce4b6eb75d023a26b5c61d5efd2c5c25b877548566636dc06R64-R99)