### PR TITLE
fix(tests): keep the 3FS mock reader on host memory

### DIFF
--- a/tests/unit/threefs/conftest.py
+++ b/tests/unit/threefs/conftest.py
@@ -38,10 +38,24 @@ load_library_functions(resolve_runtime_lib_name())
 FRAMEWORK = get_framework_op(os.getenv("TEST_FASTSAFETENSORS_FRAMEWORK", "please set"))
 
 
+def using_mock_reader() -> bool:
+    """True when the 3FS reader is the CI mock rather than the real package."""
+    try:
+        import fastsafetensor_3fs_reader as reader
+    except ImportError:
+        return True
+    return getattr(reader, "ThreeFSFileReader", None) is MockFileReader
+
+
 def get_device(framework: FrameworkOpBase):
     dev_is_gpu = is_gpu_found()
     device = "cpu"
-    if dev_is_gpu:
+    # MockFileReader copies into dev_ptr with ctypes.memmove, which requires
+    # host memory -- handing it a device pointer segfaults the interpreter.
+    # Only the real 3FS reader can DMA into device memory, so stay on the CPU
+    # whenever the mock is standing in. CI has no GPU, which is why this only
+    # ever bit people running the suite on a GPU host.
+    if dev_is_gpu and not using_mock_reader():
         if framework.get_name() == "pytorch":
             device = "cuda:0"
         elif framework.get_name() == "paddle":


### PR DESCRIPTION
Fixes #99.

`get_device()` picked `cuda:0` whenever a GPU was present, so `submit_io` allocated device memory and `MockFileReader.read_chunked` copied into it with `ctypes.memmove` — a host copy through a device pointer. It segfaults the interpreter and takes the whole pytest run with it, so `pytest tests/unit` couldn't complete on any GPU host. The mock already documented that `dev_ptr` must be host memory; nothing enforced it. CI has no GPU runners, hence green.

Fix: pick a GPU only when the real `fastsafetensor_3fs_reader` is installed — the only reader that can DMA into device memory. It compares `ThreeFSFileReader` against `MockFileReader`, because the session fixture injects the mock into `sys.modules` and a bare import succeeds either way.

Measured on a GB10 (CUDA 13.1, torch 2.10), same tree:

| | threefs | full `tests/unit` |
|---|---|---|
| `--gpus all`, before | SIGSEGV | killed mid-run |
| `--gpus all`, after | 4 passed | 188 passed |
| no GPU, either | 4 passed | 186 passed |

Trade-off: no GPU coverage of the 3FS path while mocked — it never worked anyway. The alternative is teaching the mock a real H2D copy; happy to switch.
