### PR TITLE
Clamp queue_size to the device memory budget instead of failing

### DIFF
--- a/fastsafetensors/_planner.py
+++ b/fastsafetensors/_planner.py
@@ -40,6 +40,10 @@ any one rank,
 With ``group_size == 1``, ``G(i) == i`` and this reduces to ``R[i+1]``.
 ``yield_clone`` is 1 when a non-resident yielded tensor is cloned, else 0.
 
+``fit_queue_size`` inverts this bound exactly: given a budget it returns the
+deepest queue size whose plan still fits. ``ParallelLoader`` clamps its own
+pipeline depth to that, so too small a budget costs throughput, not the load.
+
 The budget itself is the caller's to choose -- only the caller knows what
 else will live on the device. A caller sizing it from free memory should
 keep a reserve for allocator rounding and the copier's fixed pools (5% or
@@ -142,6 +146,39 @@ def pipeline_depth(queue_size: int) -> int:
     return queue_size + 2
 
 
+def load_depth(queue_size: int, group_size: int = 1) -> int:
+    """Concurrently live device buffers: ``pipeline_depth`` plus, under
+    broadcast, one in-flight receive tensor.
+
+    The ``depth`` ``plan_file_budgets`` expects. ``fit_queue_size`` inverts this
+    function, so both live here and cannot drift apart.
+    """
+    return pipeline_depth(queue_size) + (1 if group_size > 1 else 0)
+
+
+def _effective_depth(
+    depth: int, transient_multiplier: int, account_for_yield_clone: bool
+) -> int:
+    """Live transient buffers, each charged one chunk budget."""
+    return depth * transient_multiplier + int(account_for_yield_clone)
+
+
+def _group_resident(stats: List[FileWeightStats], group_size: int) -> List[int]:
+    """Cumulative kept bytes through the end of each file's batch group: just
+    ``R[i+1]`` when ``group_size == 1``, else the group total for every file in
+    it, since broadcast puts the whole group in flight at once.
+    """
+    kept_through_group = []
+    running = 0
+    for st in stats:
+        running += st.kept_bytes
+        kept_through_group.append(running)
+    return [
+        kept_through_group[min((i // group_size + 1) * group_size, len(stats)) - 1]
+        for i in range(len(stats))
+    ]
+
+
 def collect_file_stats(
     metas: List[Tuple[str, SafeTensorsMetadata]],
     keep_tensor: Optional[Callable[[str], bool]] = None,
@@ -221,19 +258,8 @@ def plan_file_budgets(
         )
     if group_size < 1:
         raise ValueError(f"group_size must be >= 1, got {group_size}")
-    eff_depth = depth * transient_multiplier + int(account_for_yield_clone)
-    # Cumulative kept bytes through the end of each file's batch group. With
-    # group_size == 1 this is just R[i+1]; under broadcast the whole group is
-    # in flight at once, so every file in it is charged the group's total.
-    kept_through_group = []
-    running = 0
-    for end in range(len(stats)):
-        running += stats[end].kept_bytes
-        kept_through_group.append(running)
-    group_resident = [
-        kept_through_group[min((i // group_size + 1) * group_size, len(stats)) - 1]
-        for i in range(len(stats))
-    ]
+    eff_depth = _effective_depth(depth, transient_multiplier, account_for_yield_clone)
+    group_resident = _group_resident(stats, group_size)
     budgets = []
     for i, st in enumerate(stats):
         resident = group_resident[i] if accumulate_resident else 0
@@ -246,8 +272,83 @@ def plan_file_budgets(
                 f"Model does not fit device_memory_budget: loading '{st.path}' "
                 f"needs >= {required} bytes ({resident} resident + {eff_depth} x "
                 f"{st.largest_tensor} transient), budget is {device_memory_budget}. "
-                f"Reduce pipeline depth (queue_size), free device memory, or pass "
-                f"a larger explicit budget."
+                + (
+                    # Already as shallow as a load gets: ParallelLoader clamps
+                    # to this, so queue_size is a spent lever by now.
+                    "The pipeline is already fully serial (queue_size=-1): free "
+                    "device memory or pass a larger explicit budget."
+                    if depth <= load_depth(-1, group_size)
+                    else "Reduce pipeline depth (queue_size), free device "
+                    "memory, or pass a larger explicit budget."
+                )
             )
         budgets.append(b)
     return budgets
+
+
+def fit_queue_size(
+    requested: int,
+    stats: List[FileWeightStats],
+    device_memory_budget: int,
+    max_batch_bytes: Optional[int] = None,
+    accumulate_resident: bool = True,
+    transient_multiplier: int = 1,
+    group_size: int = 1,
+    account_for_yield_clone: bool = False,
+) -> Optional[int]:
+    """The deepest queue size ``<= requested`` whose plan fits the budget.
+
+    ``None`` when no queue size fits: some file's largest tensor overflows the
+    budget even loaded serially, so only freeing memory helps.
+
+    The exact inverse of the bound ``plan_file_budgets`` enforces, not a search:
+    the returned queue size is guaranteed to plan, and one deeper (when the
+    result was clamped) is guaranteed to raise. Every input comes from the
+    headers, so no trial load is needed.
+
+    Takes ``plan_file_budgets``' arguments minus ``depth`` -- that is the
+    unknown. Ranks must already pass an identical budget (see the module
+    docstring), which makes the clamp identical too: no collective needed.
+    """
+    if transient_multiplier < 1:
+        raise ValueError(
+            f"transient_multiplier must be >= 1, got {transient_multiplier}"
+        )
+    if group_size < 1:
+        raise ValueError(f"group_size must be >= 1, got {group_size}")
+    if device_memory_budget <= 0:
+        return None
+    group_resident = _group_resident(stats, group_size)
+    # Largest eff_depth every file can afford. The plan's test,
+    # (budget - resident) // eff_depth >= largest, is exactly
+    # budget - resident >= largest * eff_depth for eff_depth >= 1, so this
+    # inverts with no floor-division slack either way.
+    cap = None  # None: no kept tensor constrains the depth
+    for i, st in enumerate(stats):
+        if st.largest_tensor <= 0:
+            continue  # nothing kept in this file: no chunk, no constraint
+        if max_batch_bytes is not None and max_batch_bytes < st.largest_tensor:
+            # The cap floors the budget below the atomic load unit at every
+            # depth, so no depth helps.
+            return None
+        headroom = device_memory_budget - (
+            group_resident[i] if accumulate_resident else 0
+        )
+        # Floors to <= 0 when even one buffer does not fit (headroom may be
+        # negative once resident alone overruns the budget); `room` below turns
+        # that into None, so no separate guard is needed here.
+        limit = headroom // st.largest_tensor
+        cap = limit if cap is None else min(cap, limit)
+    if cap is None:
+        return requested
+    # eff_depth = load_depth(qs, group) * multiplier + clone <= cap, solved for
+    # the load_depth term, then inverted.
+    room = cap - int(account_for_yield_clone)
+    if room < transient_multiplier:
+        return None  # not even one live buffer fits alongside the clone
+    base = room // transient_multiplier - (1 if group_size > 1 else 0)
+    if base < 1:
+        return None
+    # Not injective at the bottom: queue_size=-1 and no queue at all both give
+    # base depth 1, so 1 maps back to -1.
+    return min(requested, -1 if base == 1 else base - 2)

--- a/fastsafetensors/parallel_loader.py
+++ b/fastsafetensors/parallel_loader.py
@@ -203,6 +203,10 @@ class PipelineParallel:
         # Single-process yields borrow the file buffer and require a clone.
         self.need_clone = pg.size() == 1
 
+        # Before _create_batches, which reports any queue_size clamp.
+        self.print_log = os.getenv("FASTSAFETENSORS_DEBUG", "false").lower() == "true"
+        self.log_prefix = f"PG{pg.rank() if pg is not None else 0}"
+
         # Batch files (or, with max_batch_bytes / device_memory_budget,
         # sub-file chunk-batches)
         self.weight_files_batches = self._create_batches(pg)
@@ -210,8 +214,13 @@ class PipelineParallel:
         # Producer-consumer communication
         # For unbuffered behavior (queue_size=0), we use a maxsize of 1 to ensure synchronization
         # but modify the producer logic to wait for consumer to process before producing next
+        # self.queue_size, not the parameter: _create_batches may have clamped
+        # it, and the runtime handshake paths read the attribute. Sizing these
+        # from the parameter would run the pipeline deeper than it was budgeted
+        # for -- a clamp from 3 to -1 would leave consumer_processed None and
+        # skip the serial handshake entirely.
         self.batch_queue: queue.Queue[Union[FileBatch, Exception, None]] = queue.Queue(
-            maxsize=max(1, queue_size)
+            maxsize=max(1, self.queue_size)
         )  # Ensure at least size 1
         self.stop_event = threading.Event()
         self.error_event = threading.Event()
@@ -219,14 +228,11 @@ class PipelineParallel:
 
         # For unbuffered behavior, we need additional synchronization
         self.consumer_processed: Optional[threading.Event] = (
-            threading.Event() if queue_size <= 0 else None
+            threading.Event() if self.queue_size <= 0 else None
         )
-        if queue_size <= 0 and self.consumer_processed is not None:
+        if self.queue_size <= 0 and self.consumer_processed is not None:
             self.consumer_processed.set()  # Initially set to allow first production
 
-        # Logging setup - get from environment variable, default to False
-        self.print_log = os.getenv("FASTSAFETENSORS_DEBUG", "false").lower() == "true"
-        self.log_prefix = f"PG{pg.rank() if pg is not None else 0}"
         fstcpp.set_gil_release(True)
 
     def _create_batches(self, pg) -> List[List[Any]]:
@@ -261,19 +267,15 @@ class PipelineParallel:
         if self.device_memory_budget is not None:
             from ._planner import (
                 collect_file_stats,
-                pipeline_depth,
+                fit_queue_size,
+                load_depth,
                 plan_file_budgets,
             )
 
             metas = [
                 (f, SafeTensorsMetadata.from_file(f, fw)) for f in self.hf_weights_files
             ]
-            # Broadcast mode adds one in-flight receive tensor (<= one chunk
-            # budget) on top of the live gbufs; the caller passing the same
-            # budget on every rank keeps the plan deterministic across ranks.
-            # batch_size also sets the group width: those files load together,
-            # one per rank, and every rank keeps all of them.
-            depth = pipeline_depth(self.queue_size) + (1 if batch_size > 1 else 0)
+            stats = collect_file_stats(metas, keep)
             account_for_yield_clone = self.need_clone and not self.accumulate_resident
             # How much transient device memory a live chunk costs is the
             # copier's own business (e.g. the unified copier's mmap+pin
@@ -281,8 +283,40 @@ class PipelineParallel:
             # costing 2x span on a shared physical pool), so ask it.
             copier = self.loader.copier_class
             multiplier = copier.chunk_transient_multiplier([f for f, _ in metas])
+            # Too small a budget for the requested depth is a reason to load
+            # more shallowly, not to fail: the budget comes from free memory at
+            # load time while queue_size is static, so nobody can pick the right
+            # depth in advance. Inputs are header-derived and the budget is
+            # identical on every rank, so all ranks clamp alike -- the lockstep
+            # broadcast needs no collective to agree.
+            fitted = fit_queue_size(
+                self.queue_size,
+                stats,
+                self.device_memory_budget,
+                max_batch_bytes=self.max_batch_bytes,
+                accumulate_resident=self.accumulate_resident,
+                transient_multiplier=multiplier,
+                group_size=batch_size,
+                account_for_yield_clone=account_for_yield_clone,
+            )
+            if fitted is None:
+                # No depth fits. Plan serially anyway, so the error reports the
+                # smallest shortfall -- the bytes the user must actually free.
+                self.queue_size = -1
+            elif fitted < self.queue_size:
+                self._log_message(
+                    f"device_memory_budget={self.device_memory_budget} does not "
+                    f"fit queue_size={self.queue_size}; loading with "
+                    f"queue_size={fitted} instead. Free device memory or raise "
+                    f"the budget to keep a deeper pipeline.",
+                    is_error=True,  # a silent throughput cut is worse
+                )
+                self.queue_size = fitted
+            # batch_size also sets the group width: those files load together,
+            # one per rank, and every rank keeps all of them.
+            depth = load_depth(self.queue_size, batch_size)
             budgets = plan_file_budgets(
-                collect_file_stats(metas, keep),
+                stats,
                 self.device_memory_budget,
                 depth,
                 max_batch_bytes=self.max_batch_bytes,

--- a/tests/unit/test_planner.py
+++ b/tests/unit/test_planner.py
@@ -11,6 +11,8 @@ from fastsafetensors._planner import (
     BudgetInfeasibleError,
     FileWeightStats,
     collect_file_stats,
+    fit_queue_size,
+    load_depth,
     pipeline_depth,
     plan_file_budgets,
 )
@@ -36,6 +38,11 @@ def test_pipeline_depth_mapping():
     assert pipeline_depth(0) == 2
     assert pipeline_depth(1) == 3
     assert pipeline_depth(4) == 6
+    # Broadcast costs one more buffer, whatever the group width: ranks receive
+    # one file at a time, so the term must not scale with the group.
+    assert [load_depth(q) for q in (-1, 0, 2)] == [1, 2, 4]
+    for group in (2, 4, 8):
+        assert [load_depth(q, group) for q in (-1, 0, 2)] == [2, 3, 5]
 
 
 # ---- copier-supplied transient multiplier ----
@@ -245,6 +252,60 @@ def test_infeasible_raises_with_details():
     assert "queue_size" in msg
 
 
+# ---- inverting the bound: the deepest queue size that fits ----
+
+
+def test_fit_queue_size_none_when_no_depth_helps():
+    # The simulation below only asserts that None is not claimed to fit; these
+    # pin the cases where None is the right answer, so the loader is told to
+    # free memory instead of being handed -1 and an OOM seconds later.
+    #
+    # A tensor larger than the whole budget, and resident growth exhausting it
+    # partway through -- neither regime is reachable from the corpus below,
+    # which always funds at least the model's kept bytes.
+    assert fit_queue_size(4, [_st("f0", 4 * GiB, largest=3 * GiB)], 2 * GiB) is None
+    assert fit_queue_size(4, [_st("f0", 1)], 0) is None
+    stats = [_st(f"f{i}", 2 * GiB, largest=1 * GiB) for i in range(10)]
+    assert fit_queue_size(0, stats, 12 * GiB) is None
+    # max_batch_bytes floors the budget below the atomic tensor at every depth,
+    # so no depth helps there either -- but only while it actually binds.
+    one = [_st("f0", 4 * GiB, largest=2 * GiB)]
+    assert (
+        fit_queue_size(
+            4, one, 100 * GiB, max_batch_bytes=1 * GiB, accumulate_resident=False
+        )
+        is None
+    )
+    assert (
+        fit_queue_size(
+            4, one, 100 * GiB, max_batch_bytes=2 * GiB, accumulate_resident=False
+        )
+        == 4
+    )
+
+
+def test_fit_queue_size_unconstrained_when_nothing_is_kept():
+    # An all-filtered load has no chunk to size: pass the request through.
+    stats = [FileWeightStats(f"f{i}", 0, 0, 0) for i in range(3)]
+    assert fit_queue_size(3, stats, 1 * GiB) == 3
+
+
+def test_infeasible_advice_stops_blaming_queue_size_once_serial():
+    # The loader clamps before planning, so once a serial plan fails queue_size
+    # is a spent lever -- naming it sends the user after a dead retry.
+    stats = [_st("f0", 4 * GiB, largest=3 * GiB)]
+    with pytest.raises(BudgetInfeasibleError) as ei:
+        plan_file_budgets(stats, 2 * GiB, load_depth(-1))
+    assert "already fully serial" in str(ei.value), str(ei.value)
+    # Deeper than serial, the suggestion still applies.
+    with pytest.raises(BudgetInfeasibleError, match="Reduce pipeline depth"):
+        plan_file_budgets(stats, 2 * GiB, load_depth(0))
+    # Broadcast's extra buffer means serial is depth 2, not 1, there.
+    with pytest.raises(BudgetInfeasibleError) as ei:
+        plan_file_budgets(stats, 2 * GiB, load_depth(-1, 2), group_size=2)
+    assert "already fully serial" in str(ei.value), str(ei.value)
+
+
 def test_nonpositive_budget_and_bad_depth():
     with pytest.raises(BudgetInfeasibleError):
         plan_file_budgets([_st("f", 1)], 0, depth=1)
@@ -278,7 +339,13 @@ def _chunk_sizes(span, budget):
 
 
 def _simulate_peak(
-    stats, budgets, base_depth, group_size=1, accumulate_resident=True, multiplier=1
+    stats,
+    budgets,
+    base_depth,
+    group_size=1,
+    accumulate_resident=True,
+    multiplier=1,
+    account_for_yield_clone=False,
 ):
     """Replay the load and return the worst peak on any single rank.
 
@@ -288,6 +355,12 @@ def _simulate_peak(
     on every rank once it is consumed. A rank holds up to `base_depth` of its
     own chunk buffers (each costing `multiplier` x its span) plus, under
     broadcast, one in-flight receive tensor.
+
+    With `account_for_yield_clone`, a yielded tensor is copied while its chunk
+    buffer is still live, so the in-flight file's largest tensor is charged on
+    top. That is the physical worst case; the planner reserves a whole chunk
+    budget (>= this), so the assertion tests that the reservation suffices
+    rather than restating how it is computed.
 
     Resident is accumulated from the replay itself rather than from the
     planner's R[G(i)+1] formula, so a wrong formula cannot cancel out here.
@@ -315,6 +388,8 @@ def _simulate_peak(
         for r in batches[k]:
             own = sum(b[r][1] for b in batches[start : k + 1] if r in b)
             live = multiplier * own + (recv if group_size > 1 else 0)
+            if account_for_yield_clone:
+                live += stats[batches[k][r][0]].largest_tensor
             peak = max(peak, resident + live)
     return peak
 
@@ -322,7 +397,7 @@ def _simulate_peak(
 def test_simulation_peak_within_budget():
     rng = random.Random(1234)
     trials = 400
-    multi_chunk = infeasible = grouped = 0
+    multi_chunk = infeasible = grouped = clamped = 0
     for trial in range(trials):
         n = rng.randint(1, 12)
         stats = []
@@ -341,6 +416,9 @@ def test_simulation_peak_within_budget():
         mult = rng.choice([1, 1, 2])
         depth = pipeline_depth(qs) + (1 if group_size > 1 else 0)
         acc = rng.random() < 0.5
+        # The planner accepts any combination, so vary it freely: one
+        # hand-checked case aside, this is the clone term's only coverage.
+        clone = rng.random() < 0.5
         max_largest = max(s.largest_tensor for s in stats)
         # Headroom is sometimes too small for the largest-tensor floor, so the
         # planner has to refuse rather than hand back an unusable budget.
@@ -357,10 +435,58 @@ def test_simulation_peak_within_budget():
                 accumulate_resident=acc,
                 transient_multiplier=mult,
                 group_size=group_size,
+                account_for_yield_clone=clone,
             )
         except BudgetInfeasibleError:
             infeasible += 1
+            # The clamp must agree with the plan on every refusal: its fallback
+            # has to plan, with nothing deeper that would have. Conservative
+            # costs throughput; optimistic reintroduces the OOM.
+            fitted = fit_queue_size(
+                qs,
+                stats,
+                budget,
+                accumulate_resident=acc,
+                transient_multiplier=mult,
+                group_size=group_size,
+                account_for_yield_clone=clone,
+            )
+            assert fitted is None or fitted < qs, (trial, fitted, qs)
+            if fitted is not None:
+                clamped += 1
+                plan_file_budgets(
+                    stats,
+                    budget,
+                    load_depth(fitted, group_size),
+                    accumulate_resident=acc,
+                    transient_multiplier=mult,
+                    group_size=group_size,
+                    account_for_yield_clone=clone,
+                )
+                with pytest.raises(BudgetInfeasibleError):
+                    plan_file_budgets(
+                        stats,
+                        budget,
+                        load_depth(fitted + 1, group_size),
+                        accumulate_resident=acc,
+                        transient_multiplier=mult,
+                        group_size=group_size,
+                        account_for_yield_clone=clone,
+                    )
             continue
+        # Feasible: the clamp must leave the request untouched.
+        assert (
+            fit_queue_size(
+                qs,
+                stats,
+                budget,
+                accumulate_resident=acc,
+                transient_multiplier=mult,
+                group_size=group_size,
+                account_for_yield_clone=clone,
+            )
+            == qs
+        ), (trial, qs)
         assert all(b >= st.largest_tensor for b, st in zip(budgets, stats))
         if any(
             len(_chunk_sizes(st.span_bytes, b)) >= 3 for st, b in zip(stats, budgets)
@@ -375,11 +501,21 @@ def test_simulation_peak_within_budget():
             group_size=group_size,
             accumulate_resident=acc,
             multiplier=mult,
+            account_for_yield_clone=clone,
         )
         # acc=True: resident + transient <= budget. acc=False: the plan bounds
         # the transient side only (destinations preallocated), and the sim
         # models exactly that side -> same assertion.
-        assert peak <= budget, (trial, peak, budget, acc, group_size, mult, qs)
+        assert peak <= budget, (
+            trial,
+            peak,
+            budget,
+            acc,
+            group_size,
+            mult,
+            qs,
+            clone,
+        )
     # Guard against the corpus quietly degenerating: the bound says nothing
     # where nothing is split, the infeasibility floor is untested if no plan is
     # ever refused, and the group-resident rule is untested without multi-rank
@@ -387,6 +523,8 @@ def test_simulation_peak_within_budget():
     assert multi_chunk > 40, f"only {multi_chunk}/{trials} trials split a file 3+ ways"
     assert infeasible > 20, f"only {infeasible}/{trials} trials hit the budget floor"
     assert grouped > 40, f"only {grouped}/{trials} trials used multi-rank groups"
+    # Refusals no shallower pipeline can rescue only exercise the None path.
+    assert clamped > 10, f"only {clamped}/{trials} trials clamped to a feasible depth"
 
 
 # ---- collect_file_stats on real files ----
@@ -478,6 +616,71 @@ def test_single_process_loader_budgets_yield_clone(
         assert captured["account_for_yield_clone"] is expected_account_for_clone
     finally:
         pl.close()
+
+
+def test_loader_clamps_queue_size_instead_of_failing(input_files, framework):
+    if framework.get_name() != "pytorch":
+        pytest.skip("pytorch-only integration test")
+    import torch
+    from safetensors.torch import load_file
+
+    from fastsafetensors import ParallelLoader
+
+    expected = load_file(input_files[0])
+    meta = SafeTensorsMetadata.from_file(input_files[0], framework)
+    (st,) = collect_file_stats([(input_files[0], meta)])
+    # Room for eff_depth 3; the clone takes one, leaving 2 buffers = queue_size
+    # 0. This mismatch is the normal case, not a misconfiguration: the budget
+    # comes from free memory at load time, queue_size is static.
+    budget = 3 * st.largest_tensor
+
+    pl = ParallelLoader(
+        pg=None,
+        hf_weights_files=[input_files[0]],
+        device="cpu",
+        nogds=True,
+        use_tqdm_on_load=False,
+        queue_size=3,
+        device_memory_budget=budget,
+        accumulate_resident=False,
+    )
+    try:
+        assert pl.queue_size == 0, pl.queue_size
+        # The queue and the handshake must follow the clamp, not the request:
+        # queue_size=3 creates no handshake event, so a clamp to 0 would plan
+        # for two buffers and let the producer run three ahead unsynchronized.
+        assert pl.batch_queue.maxsize == 1
+        assert pl.consumer_processed is not None
+        got = dict(pl.iterate_weights())
+    finally:
+        pl.close()
+    assert set(got.keys()) == set(expected.keys())
+    for k in expected:
+        assert torch.equal(got[k], expected[k]), k
+
+
+def test_loader_still_fails_when_no_queue_size_fits(input_files, framework):
+    if framework.get_name() != "pytorch":
+        pytest.skip("pytorch-only integration test")
+    from fastsafetensors import ParallelLoader
+
+    meta = SafeTensorsMetadata.from_file(input_files[0], framework)
+    (st,) = collect_file_stats([(input_files[0], meta)])
+    # One buffer plus its clone already exceeds this: no depth rescues it, and
+    # the clamp must not paper over that with a load that OOMs later.
+    with pytest.raises(BudgetInfeasibleError) as ei:
+        ParallelLoader(
+            pg=None,
+            hf_weights_files=[input_files[0]],
+            device="cpu",
+            nogds=True,
+            use_tqdm_on_load=False,
+            queue_size=3,
+            device_memory_budget=st.largest_tensor,
+            accumulate_resident=False,
+        )
+    # Reported against the serial plan: that shortfall is what must be freed.
+    assert "already fully serial" in str(ei.value), str(ei.value)
 
 
 def test_transient_multiplier_infeasible():


### PR DESCRIPTION
A budget too small for the requested pipeline depth was a hard BudgetInfeasibleError. But callers size the budget from the device's free memory at load time, which varies per machine and per run, while queue_size is a static setting, so nobody can pick the right depth in advance.

Add _planner.fit_queue_size, the exact inverse of the bound plan_file_budgets enforces: the deepest queue size whose plan still fits, or None when no depth does. ParallelLoader calls it before planning and clamps its own depth, logging when it does, so too small a budget costs throughput rather than the load. Every input is header-derived and the budget is already required to be identical on every rank, so all ranks clamp alike -- the lockstep broadcast needs no collective to agree on the depth. When nothing fits, plan serially anyway so the error reports the smallest shortfall, i.e. the bytes that must actually be freed.

Extract load_depth (pipeline_depth plus broadcast's receive buffer) alongside _effective_depth and _group_resident so the plan and its inverse share one definition and cannot drift apart.

Fix a latent split-brain in __init__ while here: batch_queue's maxsize and consumer_processed were derived from the queue_size parameter while every runtime handshake path reads self.queue_size. Clamping exposes it -- a clamp from 3 to -1 would leave consumer_processed None and skip the serial handshake, running the pipeline deeper than it was budgeted for.