### PR TITLE
Per-tensor residency predicate for the fit planner

### DIFF
--- a/fastsafetensors/__init__.py
+++ b/fastsafetensors/__init__.py
@@ -4,6 +4,7 @@ from importlib.metadata import version
 
 __version__ = version(__name__)
 
+from ._planner import BudgetInfeasibleError
 from .auto_loader import AutoLoader
 from .common import (
     SafeTensorsMetadata,

--- a/fastsafetensors/_planner.py
+++ b/fastsafetensors/_planner.py
@@ -26,8 +26,8 @@ Why per-file budgets are safe (the bound): let ``G(i)`` be the last file of
 file ``i``'s batch group -- the ``group_size`` files loaded concurrently, one
 per rank. While any chunk of file ``i`` is alive, resident bytes are at most
 ``R[G(i)+1]`` (only tensors of files ``<= G(i)`` have been materialized; the
-group's kept bytes are charged up front, because broadcast leaves every rank
-holding every file of the group) and every live transient buffer belongs to
+group's resident bytes are charged up front, because broadcast leaves every
+rank holding every file of the group) and every live transient buffer belongs to
 file ``i`` or a later file ``j > i``. The per-file budget ``B`` declines
 monotonically with ``R``, so every live buffer span is ``<= B[i]``. With at
 most ``depth * transient_multiplier`` buffers plus one yield clone alive on
@@ -129,9 +129,20 @@ class FileWeightStats:
     """Per-file byte accounting for the fit plan (kept tensors only)."""
 
     path: str
-    kept_bytes: int  # sum of kept tensor bytes: resident growth
+    kept_bytes: int  # sum of kept tensor bytes: what the load reads
     span_bytes: int  # last kept byte - first kept byte: single-chunk buffer size
     largest_tensor: int  # chunk floor: a tensor is the atomic load unit
+    # Subset of kept_bytes that stays on the device after the load. Equal to
+    # kept_bytes for a consumer that keeps everything, which is why the two
+    # were one number; they diverge for a consumer that relocates part of what
+    # it is handed (e.g. offloading embedding tables to host memory).
+    # None means "not measured": callers treat it as kept_bytes.
+    resident_bytes: Optional[int] = None
+
+    @property
+    def resident(self) -> int:
+        """resident_bytes, defaulting to kept_bytes when not measured."""
+        return self.kept_bytes if self.resident_bytes is None else self.resident_bytes
 
 
 def pipeline_depth(queue_size: int) -> int:
@@ -164,14 +175,14 @@ def _effective_depth(
 
 
 def _group_resident(stats: List[FileWeightStats], group_size: int) -> List[int]:
-    """Cumulative kept bytes through the end of each file's batch group: just
+    """Cumulative resident bytes through the end of each file's batch group: just
     ``R[i+1]`` when ``group_size == 1``, else the group total for every file in
     it, since broadcast puts the whole group in flight at once.
     """
     kept_through_group = []
     running = 0
     for st in stats:
-        running += st.kept_bytes
+        running += st.resident
         kept_through_group.append(running)
     return [
         kept_through_group[min((i // group_size + 1) * group_size, len(stats)) - 1]
@@ -182,25 +193,61 @@ def _group_resident(stats: List[FileWeightStats], group_size: int) -> List[int]:
 def collect_file_stats(
     metas: List[Tuple[str, SafeTensorsMetadata]],
     keep_tensor: Optional[Callable[[str], bool]] = None,
+    resident_tensor: Optional[Callable[[str], bool]] = None,
 ) -> List[FileWeightStats]:
-    """Byte accounting per file from already-parsed headers."""
+    """Byte accounting per file from already-parsed headers.
+
+    ``keep_tensor`` selects what is read; ``resident_tensor`` selects which of
+    those stay on the device once the load is done. Default (None) is that
+    everything read stays, which is what a consumer keeping every yielded
+    tensor does. A consumer that relocates a subset -- offloading embedding
+    tables to host memory, say -- passes a predicate so the plan charges only
+    the bytes that actually remain.
+
+    ``resident_tensor`` MUST be a pure function of the tensor name, identical
+    on every rank, for the same reason ``keep_tensor`` must: the fit plan is
+    recomputed independently per rank and the broadcast sequence desyncs if the
+    plans differ. Deciding residency from rank-local state -- observed free
+    memory, an offload budget consumed as the load proceeds -- breaks that
+    silently. Resolve such a policy to a name predicate before planning.
+
+    Residency does not move ``largest_tensor``: a tensor that is relocated
+    after the load is still read whole, so it still sets the chunk floor.
+    """
     stats = []
     for path, meta in metas:
-        kept = span_start = span_end = largest = 0
+        kept = span_start = span_end = largest = resident = 0
         first = True
         for name, frame in meta.tensors.items():
             if keep_tensor is not None and not keep_tensor(name):
                 continue
             s, e = frame.data_offsets[0], frame.data_offsets[1]
             kept += e - s
+            if resident_tensor is None or resident_tensor(name):
+                resident += e - s
             largest = max(largest, e - s)
             if first:
                 span_start, first = s, False
             span_end = max(span_end, e)
         stats.append(
-            FileWeightStats(path, kept, span_end - span_start if kept else 0, largest)
+            FileWeightStats(
+                path,
+                kept,
+                span_end - span_start if kept else 0,
+                largest,
+                resident,
+            )
         )
     return stats
+
+
+def has_non_resident(stats: List[FileWeightStats]) -> bool:
+    """True when any kept bytes do not stay resident.
+
+    Lets a caller decide whether a transient yielded-tensor clone needs its own
+    budget without re-deriving the predicate.
+    """
+    return any(st.resident < st.kept_bytes for st in stats)
 
 
 def plan_file_budgets(
@@ -215,12 +262,15 @@ def plan_file_budgets(
 ) -> List[int]:
     """Per-file chunk budgets satisfying the peak-memory bound.
 
-    ``accumulate_resident=True`` models consumers that keep every yielded
-    tensor (resident grows by cumulative kept bytes). ``False`` models
-    consumers whose destination memory is already allocated before the load
-    (e.g. copying into preallocated model parameters): resident growth is 0
-    and the plan degenerates to a uniform budget determined by the transient
-    depth.
+    ``accumulate_resident=True`` charges the residency recorded in ``stats``
+    (``FileWeightStats.resident``, which is every kept byte unless
+    ``collect_file_stats`` was given a ``resident_tensor`` predicate).
+    ``False`` models consumers whose destination memory is already allocated
+    before the load (e.g. copying into preallocated model parameters): resident
+    growth is 0 and the plan degenerates to a uniform budget determined by the
+    transient depth. The two booleans remain shorthand for the ends of the
+    range; a consumer that keeps only some of what it reads expresses that with
+    the predicate rather than by choosing the less-wrong bool.
 
     ``transient_multiplier`` scales the per-buffer transient cost: how many
     times over the copier stages each in-flight chunk. Only the copier knows

--- a/fastsafetensors/parallel_loader.py
+++ b/fastsafetensors/parallel_loader.py
@@ -145,6 +145,7 @@ class PipelineParallel:
         use_chunk_budget_as_allocation_size: bool = False,
         device_memory_budget: Optional[int] = None,
         accumulate_resident: bool = True,
+        resident_tensor: Optional[Callable[[str], bool]] = None,
         **kwargs,
     ):
 
@@ -199,6 +200,20 @@ class PipelineParallel:
         # destinations (e.g. model params) so resident growth is 0 and the fit
         # plan degenerates to a uniform per-file budget.
         self.accumulate_resident = accumulate_resident
+        if resident_tensor is not None and not accumulate_resident:
+            raise ValueError(
+                "resident_tensor requires accumulate_resident=True: "
+                "accumulate_resident=False charges no residency at all, so the "
+                "predicate would be silently discarded"
+            )
+        # Which kept tensors stay on the device after the load. None: all of
+        # them. Must be a pure function of the tensor name and identical on
+        # every rank -- see collect_file_stats.
+        #
+        # The plan reserves one chunk budget for a live non-resident yield, so
+        # the consumer must relocate each such tensor before asking for the
+        # next. Holding several at once overruns that reservation.
+        self.resident_tensor = resident_tensor
 
         # Single-process yields borrow the file buffer and require a clone.
         self.need_clone = pg.size() == 1
@@ -268,6 +283,7 @@ class PipelineParallel:
             from ._planner import (
                 collect_file_stats,
                 fit_queue_size,
+                has_non_resident,
                 load_depth,
                 plan_file_budgets,
             )
@@ -275,8 +291,14 @@ class PipelineParallel:
             metas = [
                 (f, SafeTensorsMetadata.from_file(f, fw)) for f in self.hf_weights_files
             ]
-            stats = collect_file_stats(metas, keep)
-            account_for_yield_clone = self.need_clone and not self.accumulate_resident
+            stats = collect_file_stats(metas, keep, self.resident_tensor)
+            # A clone of a yielded tensor only needs its own budget when it is
+            # transient. With a residency predicate that is a property of the
+            # plan, not a caller-supplied bool: reserve iff some kept bytes do
+            # not stay resident.
+            account_for_yield_clone = self.need_clone and (
+                not self.accumulate_resident or has_non_resident(stats)
+            )
             # How much transient device memory a live chunk costs is the
             # copier's own business (e.g. the unified copier's mmap+pin
             # fallback pins the chunk's pages alongside the device buffer,
@@ -725,6 +747,7 @@ class ParallelLoader(PipelineParallel):
         use_chunk_budget_as_allocation_size: bool = False,
         device_memory_budget: Optional[int] = None,
         accumulate_resident: bool = True,
+        resident_tensor: Optional[Callable[[str], bool]] = None,
         **kwargs,
     ):
         """Initialize PipelineParallelLoader with a pre-configured SafeTensorsFileLoader.
@@ -772,5 +795,6 @@ class ParallelLoader(PipelineParallel):
             use_chunk_budget_as_allocation_size=(use_chunk_budget_as_allocation_size),
             device_memory_budget=device_memory_budget,
             accumulate_resident=accumulate_resident,
+            resident_tensor=resident_tensor,
             **kwargs,
         )

--- a/tests/unit/test_planner.py
+++ b/tests/unit/test_planner.py
@@ -12,6 +12,7 @@ from fastsafetensors._planner import (
     FileWeightStats,
     collect_file_stats,
     fit_queue_size,
+    has_non_resident,
     load_depth,
     pipeline_depth,
     plan_file_budgets,
@@ -695,3 +696,128 @@ def test_transient_multiplier_infeasible():
 def test_transient_multiplier_validation():
     with pytest.raises(ValueError):
         plan_file_budgets([_st("f0", GiB)], GiB, depth=1, transient_multiplier=0)
+
+
+# ---- resident_tensor: bytes read vs bytes that stay ----
+
+
+def test_stats_default_all_kept_bytes_resident():
+    """No predicate: resident == kept, i.e. the pre-split behaviour."""
+    st = FileWeightStats("f0", 100, 100, 25)
+    assert st.resident_bytes is None
+    assert st.resident == 100
+    assert not has_non_resident([st])
+
+
+def test_collect_file_stats_resident_predicate(tmp_path):
+    """A consumer that offloads some tensors charges only what stays."""
+    metas = _metas_two_tensors(tmp_path)
+    keep_all = collect_file_stats(metas)
+    assert keep_all[0].resident == keep_all[0].kept_bytes
+    assert not has_non_resident(keep_all)
+
+    # 'big' is relocated to host after the load; only 'small' stays resident.
+    split = collect_file_stats(metas, resident_tensor=lambda n: n != "big")
+    assert split[0].kept_bytes == keep_all[0].kept_bytes  # still all read
+    assert split[0].resident < split[0].kept_bytes  # but not all kept
+    assert has_non_resident(split)
+
+
+def test_resident_predicate_makes_an_infeasible_plan_feasible():
+    """The case the bool cannot express: most of what is read is offloaded.
+
+    accumulate_resident=True charges the offloaded bytes and refuses a plan
+    that fits; False would under-charge the bytes that do stay. The predicate
+    charges exactly the resident half.
+    """
+    budget = 10 * GiB
+    files = [("f0", 8 * GiB, 1 * GiB), ("f1", 8 * GiB, 1 * GiB)]
+    all_resident = [FileWeightStats(p, k, k, lg) for p, k, lg in files]
+    # half of each file's bytes are relocated to host
+    partly = [FileWeightStats(p, k, k, lg, k // 2) for p, k, lg in files]
+
+    with pytest.raises(BudgetInfeasibleError):
+        plan_file_budgets(all_resident, budget, depth=load_depth(-1))
+
+    budgets = plan_file_budgets(partly, budget, depth=load_depth(-1))
+    assert len(budgets) == len(files)
+    assert all(b >= st.largest_tensor for b, st in zip(budgets, partly))
+
+
+def test_accumulate_resident_false_still_charges_nothing():
+    """False keeps its old meaning even when stats carry a residency model."""
+    # each file reads 8 GiB but only 4 GiB of it stays resident
+    stats = [FileWeightStats(f"f{i}", 8 * GiB, 8 * GiB, GiB, 4 * GiB) for i in range(3)]
+    charged = plan_file_budgets(stats, 20 * GiB, depth=1, accumulate_resident=True)
+    ignored = plan_file_budgets(stats, 20 * GiB, depth=1, accumulate_resident=False)
+    # ignoring residency gives a uniform budget; charging it declines per file
+    assert len(set(ignored)) == 1
+    assert charged[0] > charged[-1]
+    # and it charges the resident half, not the 8 GiB read
+    assert charged[0] == 20 * GiB - 4 * GiB
+
+
+def test_fit_queue_size_uses_resident_not_kept():
+    """A deeper queue fits once offloaded bytes stop being charged."""
+    files = [FileWeightStats(f"f{i}", 4 * GiB, 4 * GiB, GiB) for i in range(4)]
+    # same bytes read, but all of them are relocated to host after the load
+    offloaded = [FileWeightStats(f"f{i}", 4 * GiB, 4 * GiB, GiB, 0) for i in range(4)]
+    budget = 10 * GiB
+    deep = fit_queue_size(8, offloaded, budget)
+    shallow = fit_queue_size(8, files, budget)
+    # charging 16 GiB of reads against a 10 GiB budget fits at no depth at all
+    assert shallow is None
+    assert deep is not None
+
+
+def _metas_two_tensors(tmp_path):
+    """One safetensors file: a large tensor 'big' and a small tensor 'small'."""
+    import json
+    import struct
+
+    big_bytes, small_bytes = 4096, 256
+    header = {
+        "big": {"dtype": "U8", "shape": [big_bytes], "data_offsets": [0, big_bytes]},
+        "small": {
+            "dtype": "U8",
+            "shape": [small_bytes],
+            "data_offsets": [big_bytes, big_bytes + small_bytes],
+        },
+    }
+    raw = json.dumps(header).encode()
+    p = tmp_path / "shard.safetensors"
+    with open(p, "wb") as f:
+        f.write(struct.pack("<Q", len(raw)))
+        f.write(raw)
+        f.write(b"\0" * (big_bytes + small_bytes))
+    meta = SafeTensorsMetadata.from_file(str(p), _framework())
+    return [(str(p), meta)]
+
+
+def _framework():
+    import os
+
+    from fastsafetensors.frameworks import get_framework_op
+
+    return get_framework_op(os.getenv("TEST_FASTSAFETENSORS_FRAMEWORK", "pytorch"))
+
+
+def test_resident_tensor_requires_accumulate_resident(input_files, framework):
+    """The predicate must not be accepted where the plan would ignore it."""
+    if framework.get_name() != "pytorch":
+        pytest.skip("pytorch-only integration test")
+    from fastsafetensors import ParallelLoader
+
+    # accumulate_resident=False charges zero residency, so a predicate would be
+    # discarded -- yielding exactly the under-charged plan it exists to avoid.
+    with pytest.raises(ValueError, match="resident_tensor requires"):
+        ParallelLoader(
+            pg=None,
+            hf_weights_files=[input_files[0]],
+            device="cpu",
+            nogds=True,
+            use_tqdm_on_load=False,
+            device_memory_budget=1 << 30,
+            accumulate_resident=False,
+            resident_tensor=lambda name: True,
+        )


### PR DESCRIPTION
## The gap

Follows the design discussion in #71.

`accumulate_resident` is a binary: either every yielded tensor stays on the device (resident grows by cumulative kept bytes) or none does (resident growth 0, the consumer copies into preallocated destinations). A consumer that keeps *some* of what it is handed and relocates the rest to host memory is neither, and picking the less-wrong bool fails in both directions.

Measured on an SGLang integration that offloads part of its embedding tables to host memory, against a real checkpoint. Identical 86 GiB budget, identical everything else:

| `accumulate_resident` | outcome |
| --- | --- |
| `True` (charges every kept byte) | `BudgetInfeasibleError` — ~94 GB charged resident against an 86 GiB budget, refused on a shard needing a 400 MB transient buffer |
| `False` (charges nothing) | under-charges the bytes that do stay; OOMs mid-load |
| `resident_tensor` predicate | loads, with output correctness verified against the same model loaded conventionally |

Load time matches what I got by hand-picking a `max_batch_bytes` for the same checkpoint, to within a couple of percent on single runs. Now the planner derives the bound instead of the user guessing a chunk size that happens to work.

## The change

`FileWeightStats.kept_bytes` meant two things at once: bytes the load reads, and bytes that stay resident afterwards. They are the same number only when the consumer keeps everything, which is why one field served. Splitting them:

- `FileWeightStats.resident_bytes` + `.resident` property; `kept_bytes` recommented as
  "what the load reads"
- `collect_file_stats(metas, keep_tensor=None, resident_tensor=None)`; `_group_resident`
  sums `.resident`
- `has_non_resident(stats)`, used to derive `account_for_yield_clone` rather than taking
  it from a bool
- `resident_tensor` threaded through both `PipelineParallel` and `ParallelLoader`
- `BudgetInfeasibleError` exported (vLLM needs to catch it specifically; today that means
  importing `_planner` or catching bare `ValueError`)

No signature change to `plan_file_budgets` or `fit_queue_size`. `accumulate_resident=False` still charges 0; `True` now defers to the stats, which are every kept byte unless a predicate was supplied. Existing callers are untouched, and `FileWeightStats` takes the new field with a default, so four-positional-argument construction still works.

## Two documented obligations on the caller

**`resident_tensor` must be a pure function of the tensor name, identical on every rank.** Same reason `keep_tensor` must: the plan is recomputed per rank and the broadcast desyncs if plans differ. Residency policy is naturally tempting to express as "offload until my host budget is full", which is stateful and rank-local; resolve it to a name predicate before planning. In my integration the policy resolves once at startup and then applies by name, so there is no runtime component to launder.

**The consumer must relocate each non-resident tensor before requesting the next.** The plan reserves one chunk budget for a live non-resident yield. A consumer batching its relocations would exceed that. Mine relocates each tensor inside the iteration, before taking the next. This obligation did not exist under the bool (`False` meant nothing was ever resident); a predicate names tensors but says nothing about timing, so it is new.

Passing `resident_tensor` with `accumulate_resident=False` now raises: that combination charges no residency at all, so the predicate would be silently discarded — landing on exactly the under-charged plan it exists to prevent.

## Noted but unchanged

`account_for_yield_clone` is load-wide and enters `_effective_depth` as a `+1` on the divisor, so declaring one small tensor non-resident tightens every file's budget by a whole chunk unit. With a 24 GiB budget, a 4 GiB largest tensor that stays resident and 20 GiB kept, the plan is feasible at `b = 4 GiB`; freeing 1 MiB via the predicate takes `eff_depth` from 1 to 2 and `b` to ~2 GiB, refusing a plan that fits.

This is within the stated bound — `peak <= R[G(i)+1] + (depth * m + yield_clone) * B[i]` already charges the clone a full chunk budget — so it is looseness, not a safety violation, and it only bites single-process loads where the largest tensor is one of the resident ones. The tighter form would charge the clone additively, sized to the largest non-resident tensor, rather than as a depth unit. That would change the bound and both planner signatures, so maybe later, let me know. 

## Testing

- `tests/unit/test_planner.py`: 32 passed (26 pre-existing + 6 new)
- `tests/unit` overall, plus flake8 and mypy: clean
- `make unittest` is not a clean claim — it includes `tests/vllm/test_vllm.py` and vLLM is not installed in this environment, so that leg fails environmentally rather than on the code. I ran the `tests/unit` portion instead.
- The one pre-existing `dstorage` failure reproduces identically on unmodified ff294f0.

New tests cover: default stats treating all kept bytes as resident; the predicate splitting read from resident; a plan infeasible under `True` becoming feasible with the predicate; `accumulate_resident=False` still charging nothing; `fit_queue_size` using resident rather than kept; and the rejected `resident_tensor` + `accumulate_resident=False` combination.

